### PR TITLE
Adding the ability to configure an agent to join an Elastic Pool in BYOS

### DIFF
--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -57,7 +57,7 @@ def set_last_sequence_number():
     pass
 
 def set_extension_disabled_markup():
-  config = get_configutation_from_settings()
+  config = get_configuration_from_settings()
   markup_file = '{0}/{1}'.format(config['AgentWorkingFolder'], Constants.disable_markup_file_name)
   extension_settings_file_path = '{0}/{1}.settings'.format(handler_utility._context._config_dir , handler_utility._context._seq_no)
   handler_utility.log('Writing contents of {0} to {1}'.format(extension_settings_file_path, markup_file))
@@ -355,7 +355,7 @@ def validate_inputs(config):
     except Exception as e:
       set_error_status_and_error_exit(e, RMExtensionStatus.rm_extension_status['ValidatingInputs']['operationName'], getattr(e,'Code'))
 
-def get_configutation_from_settings():
+def get_configuration_from_settings():
   try:
     public_settings = handler_utility.get_public_settings()
     if(public_settings == None):
@@ -623,7 +623,7 @@ def schedule_run_agent(config):
 def enable():
   handler_utility.set_handler_status(Util.HandlerStatus('Installing'))
   pre_validation_checks()
-  config = get_configutation_from_settings()
+  config = get_configuration_from_settings()
   compare_sequence_number(config)
   settings_are_same = test_extension_settings_are_same_as_disabled_version(config)
   if(settings_are_same):
@@ -665,7 +665,7 @@ def disable():
 
 def uninstall():
   global configured_agent_exists
-  config = get_configutation_from_settings()
+  config = get_configuration_from_settings()
   configured_agent_exists = ConfigureDeploymentAgent.is_agent_configured(config['AgentWorkingFolder'])
   extension_update_file = '{0}/{1}'.format(config['AgentWorkingFolder'], Constants.update_file_name)
   is_udpate_scenario = os.path.isfile(extension_update_file)

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -168,10 +168,16 @@ def install_dependencies(config):
     sleep(sleep_interval_in_sec)
   handler_utility.add_handler_sub_status(Util.HandlerSubStatus('InstalledDependencies'))
   
-def compare_sequence_number():
+def compare_sequence_number(config):
   try:
     sequence_number = int(handler_utility._context._seq_no)
     last_sequence_number = get_last_sequence_number()
+    if(config.IsPipelinesAgent and (last_sequence_number != -1) and (sequence_number > last_sequence_number)):
+      handler_utility.log(RMExtensionStatus.rm_extension_status['SkippedInstallation']['Message'])
+      handler_utility.log('Skipping enable since a Pipelines Agent may only install once. Seq number: {0}. Last Seq Number: {1}.'.format(sequence_number, last_sequence_number))
+      handler_utility.add_handler_sub_status(Util.HandlerSubStatus('SkippedInstallation'))
+      handler_utility.set_handler_status(Util.HandlerStatus('Enabled', 'success'))
+      exit_with_code(0)
     if((sequence_number == last_sequence_number) and not(test_extension_disabled_markup())):
       handler_utility.log(RMExtensionStatus.rm_extension_status['SkippedInstallation']['Message'])
       handler_utility.log('Skipping enable since seq numbers match. Seq number: {0}.'.format(sequence_number))
@@ -535,7 +541,7 @@ def enable():
   handler_utility.set_handler_status(Util.HandlerStatus('Installing'))
   pre_validation_checks()
   config = get_configutation_from_settings()
-  compare_sequence_number()
+  compare_sequence_number(config)
   settings_are_same = test_extension_settings_are_same_as_disabled_version()
   if(settings_are_same):
     handler_utility.log("Skipping extension enable.")

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -383,6 +383,11 @@ def get_configutation_from_settings():
     if(public_settings.has_key('UserName')):
       configure_agent_as_username = public_settings['UserName']
 
+    if(is_pipelines_agent):
+      working_folder = Constants.agent_working_folder_pipelines
+    else:
+      working_folder = Constants.agent_working_folder
+
     handler_utility.log('Done reading config settings from file...')
     handler_utility.add_handler_sub_status(Util.HandlerSubStatus('SuccessfullyReadSettings'))
     return {
@@ -392,7 +397,7 @@ def get_configutation_from_settings():
              'DeploymentGroup':deployment_group_name, 
              'AgentName':agent_name, 
              'Tags' : tags,
-             'AgentWorkingFolder':Constants.agent_working_folder,
+             'AgentWorkingFolder':working_folder,
              'ConfigureAgentAsUserName': configure_agent_as_username,
              'IsPipelinesAgent' : is_pipelines_agent,
              'PoolName' : pool_name

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -594,17 +594,21 @@ def test_extension_settings_are_same_as_disabled_version(config):
     return False
 
 def schedule_run_agent(config):
-  handler_utility.log(' creating AzDevOps account')
-  os.system('sudo useradd -m AzDevOps')
-  os.system('sudo usermod -a -G sudo AzDevOps')
-  os.system('sudo usermod -a -G adm AzDevOps')
-  os.system('echo \'AzDevOps ALL=NOPASSWD: ALL\' >> /etc/sudoers')
+  try:
+    handler_utility.log(' creating AzDevOps account')
+    os.system('sudo useradd -m AzDevOps')
+    os.system('sudo usermod -a -G sudo AzDevOps')
+    os.system('sudo usermod -a -G adm AzDevOps')
+    os.system('echo \'AzDevOps ALL=NOPASSWD: ALL\' >> /etc/sudoers')
 
-  runArgs = ''
-  if(config.SingleUse):
-    runArgs = '--once'
-  
-  os.system('echo "sudo runuser AzDevOps -c \"/bin/bash {0}/run.sh {1}\"" | at now'.format(config.AgentWorkingFolder, runArgs))
+    runArgs = ''
+    if(config.SingleUse):
+      runArgs = '--once'
+    
+    os.system('echo "sudo runuser AzDevOps -c \"/bin/bash {0}/run.sh {1}\"" | at now'.format(config.AgentWorkingFolder, runArgs))
+  except Exception as e:
+    handler_utility.log('Failed to schedule Run for Pipelines Agent. Error: {0}'.format(getattr(e,'message')))
+    set_error_status_and_error_exit(e, RMExtensionStatus.rm_extension_status['ScheduleRun']['operationName'], RMExtensionStatus.rm_extension_status['ScheduleRun']['Code'])
 
 def enable():
   handler_utility.set_handler_status(Util.HandlerStatus('Installing'))

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -529,6 +529,10 @@ def test_extension_settings_do_not_permit_enable():
         new_extension_is_pipelines_agent = new_extension_is_pipelines_agent['IsPipelinesAgent']
 
       if(old_extension_public_settings != new_extension_is_pipelines_agent):
+        handler_utility.log('Disabled version settings and new version settings differ on IsPipelinesAgent setting.')
+        handler_utility.log('Switching between Deployment and Pipelines Agent is not permitted.')
+        handler_utility.log('Disabled version settings: {0}'.format(old_extension_public_settings))
+        handler_utility.log('New version settings: {0}'.format(extension_public_settings))
         return True
 
       if(Util.ordered_json_object(old_extension_public_settings) == Util.ordered_json_object(extension_public_settings)):

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -232,7 +232,8 @@ def format_tags_input(tags_input):
 
 def validate_inputs(config):
   # If we are installing an agent for BYOS, we do not need to verify deployment group settings.
-  if(config['IsBYOSAgent']):
+  if(config['IsPipelinesAgent']):
+    handler_utility.log("Skipping input validation because this is a BYOS agent.")
     return
   try:
     invalid_pat_error_message = "Please make sure that the Personal Access Token entered is valid and has 'Deployment Groups - Read & manage' scope."
@@ -314,16 +315,16 @@ def get_configutation_from_settings():
       protected_settings = {}
 
     is_byos = False
-    if(public_settings.has_key('IsBYOSAgent')):
-      is_byos = public_settings['IsBYOSAgent']
+    if(public_settings.has_key('IsPipelinesAgent')):
+      is_byos = public_settings['IsPipelinesAgent']
 
     byos_pool = ''
-    if(public_settings.has_key('BYOSPool')):
-      byos_pool = public_settings['BYOSPool']
+    if(public_settings.has_key('PoolName')):
+      byos_pool = public_settings['PoolName']
 
     if(is_byos):
       handler_utility.log('Configured as a BYOS agent')
-      handler_utility.verify_input_not_null('BYOSPool', byos_pool)
+      handler_utility.verify_input_not_null('PoolName', byos_pool)
       handler_utility.log('BYOS Pool : {0}'.format(byos_pool))
 
     pat_token = ''
@@ -387,8 +388,8 @@ def get_configutation_from_settings():
              'Tags' : tags,
              'AgentWorkingFolder':Constants.agent_working_folder,
              'ConfigureAgentAsUserName': configure_agent_as_username,
-             'IsBYOSAgent' : is_byos,
-             'BYOSPool' : byos_pool
+             'IsPipelinesAgent' : is_byos,
+             'PoolName' : byos_pool
           }
   except Exception as e:
     set_error_status_and_error_exit(e, RMExtensionStatus.rm_extension_status['ReadingSettings']['operationName'], RMExtensionStatus.rm_extension_status['InputConfigurationError'])
@@ -439,7 +440,7 @@ def register_agent(config):
     handler_utility.log('Configuring agent...')
     ConfigureDeploymentAgent.configure_agent(config['VSTSUrl'], config['PATToken'], config['TeamProject'], \
       config['DeploymentGroup'], config['ConfigureAgentAsUserName'], config['AgentName'], config['AgentWorkingFolder'], \
-      config['IsBYOSAgent'], config['BYOSPool'])
+      config['IsPipelinesAgent'], config['PoolName'])
     handler_utility.log('Agent configured successfully')
     
     handler_utility.add_handler_sub_status(Util.HandlerSubStatus('ConfiguredDeploymentAgent'))

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -231,9 +231,9 @@ def format_tags_input(tags_input):
   return ret_val
 
 def validate_inputs(config):
-  # If we are installing an agent for BYOS, we do not need to verify deployment group settings.
+  # If we are installing an agent for Pipelines, we do not need to verify deployment group settings.
   if(config['IsPipelinesAgent']):
-    handler_utility.log("Skipping input validation because this is a BYOS agent.")
+    handler_utility.log("Skipping input validation because this is a Pipelines agent.")
     return
   try:
     invalid_pat_error_message = "Please make sure that the Personal Access Token entered is valid and has 'Deployment Groups - Read & manage' scope."
@@ -314,18 +314,18 @@ def get_configutation_from_settings():
     if(protected_settings == None):
       protected_settings = {}
 
-    is_byos = False
+    is_pipelines_agent = False
     if(public_settings.has_key('IsPipelinesAgent')):
-      is_byos = public_settings['IsPipelinesAgent']
+      is_pipelines_agent = public_settings['IsPipelinesAgent']
 
-    byos_pool = ''
+    pool_name = ''
     if(public_settings.has_key('PoolName')):
-      byos_pool = public_settings['PoolName']
+      pool_name = public_settings['PoolName']
 
-    if(is_byos):
-      handler_utility.log('Configured as a BYOS agent')
-      handler_utility.verify_input_not_null('PoolName', byos_pool)
-      handler_utility.log('BYOS Pool : {0}'.format(byos_pool))
+    if(is_pipelines_agent):
+      handler_utility.log('Configured as a Pipelines agent')
+      handler_utility.verify_input_not_null('PoolName', pool_name)
+      handler_utility.log('Pool Name : {0}'.format(pool_name))
 
     pat_token = ''
     if((protected_settings.__class__.__name__ == 'dict') and protected_settings.has_key('PATToken')):
@@ -349,7 +349,7 @@ def get_configutation_from_settings():
     team_project_name = ''
     if(public_settings.has_key('TeamProject')):
       team_project_name = public_settings['TeamProject']
-    if(not is_byos):
+    if(not is_pipelines_agent):
       handler_utility.verify_input_not_null('TeamProject', team_project_name)
       handler_utility.log('Team Project : {0}'.format(team_project_name))
 
@@ -358,7 +358,7 @@ def get_configutation_from_settings():
       deployment_group_name = public_settings['DeploymentGroup']
     elif(public_settings.has_key('MachineGroup')):
       deployment_group_name = public_settings['MachineGroup']
-    if(not is_byos):
+    if(not is_pipelines_agent):
       handler_utility.verify_input_not_null('DeploymentGroup', deployment_group_name)
       handler_utility.log('Deployment Group : {0}'.format(deployment_group_name))
 
@@ -388,8 +388,8 @@ def get_configutation_from_settings():
              'Tags' : tags,
              'AgentWorkingFolder':Constants.agent_working_folder,
              'ConfigureAgentAsUserName': configure_agent_as_username,
-             'IsPipelinesAgent' : is_byos,
-             'PoolName' : byos_pool
+             'IsPipelinesAgent' : is_pipelines_agent,
+             'PoolName' : pool_name
           }
   except Exception as e:
     set_error_status_and_error_exit(e, RMExtensionStatus.rm_extension_status['ReadingSettings']['operationName'], RMExtensionStatus.rm_extension_status['InputConfigurationError'])

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -69,7 +69,7 @@ def set_extension_disabled_markup():
 def create_extension_update_file():
   handler_utility.log('Creating extension update file.')
   try:
-    config = config['AgentWorkingFolder']
+    config = get_configuration_from_settings()
     extension_update_file = '{0}/{1}'.format(config['AgentWorkingFolder'], Constants.update_file_name)
     with open(extension_update_file, 'w') as f:
       f.write('')

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -599,6 +599,16 @@ def schedule_run_agent(config):
     os.system('sudo useradd -m AzDevOps')
     os.system('sudo usermod -a -G sudo AzDevOps')
     os.system('sudo usermod -a -G adm AzDevOps')
+    os.system('sudo usermod -a -G docker AzDevOps')
+
+    os.system('echo "Giving AzDevOps user access to the \'/home\', \'/usr/share\', and \'/opt\' directories."')
+    os.system('sudo chmod -R 777 /home')
+    os.system('setfacl -Rdm "u:AzDevOps:rwX" /home')
+    os.system('setfacl -Rb /home/AzDevOps')
+    os.system('sudo chmod -R 777 /usr/share')
+    os.system('setfacl -Rdm "u:AzDevOps:rwX" /usr/share')
+    os.system('sudo chmod -R 777 /opt')
+    os.system('setfacl -Rdm "u:AzDevOps:rwX" /opt')
     os.system('echo \'AzDevOps ALL=NOPASSWD: ALL\' >> /etc/sudoers')
 
     runArgs = ''

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -549,7 +549,9 @@ def enable():
     download_agent_if_required(config)
     configure_agent_if_required(config)
     handler_utility.set_handler_status(Util.HandlerStatus('Installed'))
-    add_agent_tags(config)
+
+    if(not config.IsPipelinesAgent):
+      add_agent_tags(config)
     handler_utility.log('Extension is enabled.')
   
   handler_utility.set_handler_status(Util.HandlerStatus('Enabled', 'success'))

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -500,7 +500,7 @@ def add_agent_tags(config):
   except Exception as e:
       set_error_status_and_error_exit(e, RMExtensionStatus.rm_extension_status['AddingAgentTags']['operationName'], 8)
 
-def test_extension_settings_do_not_permit_enable():
+def test_extension_settings_are_same_as_disabled_version():
   try:
     old_extension_settings_file_path = "{0}/{1}".format(Constants.agent_working_folder, Constants.disable_markup_file_name)
     old_extension_settings_file_exists = os.path.isfile(old_extension_settings_file_path)
@@ -516,24 +516,6 @@ def test_extension_settings_do_not_permit_enable():
         extension_settings_file_contents = f.read()
         extension_public_settings = json.loads(extension_settings_file_contents)
         extension_public_settings = extension_public_settings['runtimeSettings'][0]['handlerSettings']['publicSettings']
-
-      #A deployment agent should not be reconfigured as a Pipelines agent, and vice-versa.
-      #Therefore, check if the settings are the same between both copies of the public settings
-      #(with not present = False) and return True (do not enable) if their values do not match.
-      old_extension_is_pipelines_agent = False
-      if(old_extension_public_settings.has_key('IsPipelinesAgent')):
-        old_extension_is_pipelines_agent = old_extension_public_settings['IsPipelinesAgent']
-      
-      new_extension_is_pipelines_agent = False
-      if(new_extension_is_pipelines_agent.has_key('IsPipelinesAgent')):
-        new_extension_is_pipelines_agent = new_extension_is_pipelines_agent['IsPipelinesAgent']
-
-      if(old_extension_public_settings != new_extension_is_pipelines_agent):
-        handler_utility.log('Disabled version settings and new version settings differ on IsPipelinesAgent setting.')
-        handler_utility.log('Switching between Deployment and Pipelines Agent is not permitted.')
-        handler_utility.log('Disabled version settings: {0}'.format(old_extension_public_settings))
-        handler_utility.log('New version settings: {0}'.format(extension_public_settings))
-        return True
 
       if(Util.ordered_json_object(old_extension_public_settings) == Util.ordered_json_object(extension_public_settings)):
         handler_utility.log('Disabled version and new extension version settings are same.')
@@ -554,8 +536,8 @@ def enable():
   pre_validation_checks()
   config = get_configutation_from_settings()
   compare_sequence_number()
-  skip_enable = test_extension_settings_do_not_permit_enable()
-  if(skip_enable):
+  settings_are_same = test_extension_settings_are_same_as_disabled_version()
+  if(settings_are_same):
     handler_utility.log("Skipping extension enable.")
     handler_utility.add_handler_sub_status(Util.HandlerSubStatus('SkippingEnableSameSettingsAsDisabledVersion'))
   else:

--- a/ExtensionHandler/Linux/src/ConfigureDeploymentAgent.py
+++ b/ExtensionHandler/Linux/src/ConfigureDeploymentAgent.py
@@ -130,7 +130,7 @@ def remove_existing_agent(working_folder):
     _write_configuration_log(e.args[0])
     raise
 
-def configure_agent(vsts_url, pat_token, project_name, deployment_group_name, configure_agent_as_username, agent_name, working_folder, is_byos_agent, byos_pool):
+def configure_agent(vsts_url, pat_token, project_name, deployment_group_name, configure_agent_as_username, agent_name, working_folder, is_pipelines_agent, pool_name):
   global agent_listener_path
   global log_function
   try:
@@ -142,7 +142,7 @@ def configure_agent(vsts_url, pat_token, project_name, deployment_group_name, co
       _write_configuration_log('Agent name not provided, agent name will be set as ' + agent_name)
 
     _write_configuration_log('Configuring agent')
-    _configure_agent_internal(vsts_url, pat_token, project_name, deployment_group_name, configure_agent_as_username, agent_name, working_folder, is_byos_agent, byos_pool)
+    _configure_agent_internal(vsts_url, pat_token, project_name, deployment_group_name, configure_agent_as_username, agent_name, working_folder, is_pipelines_agent, pool_name)
     return Constants.return_success
   except Exception as e:
     _write_configuration_log(e.args[0])
@@ -242,7 +242,7 @@ def _set_folder_owner(folder, username):
     for filename in filenames:
       os.chown(os.path.join(dirpath, filename), u_id, g_id)
 
-def _configure_agent_internal(vsts_url, pat_token, project_name, deployment_group_name, configure_agent_as_username, agent_name, working_folder, is_byos_agent, byos_pool):
+def _configure_agent_internal(vsts_url, pat_token, project_name, deployment_group_name, configure_agent_as_username, agent_name, working_folder, is_pipelines_agent, pool_name):
   global agent_listener_path, agent_service_path
   _set_agent_listener_path(working_folder)
   _set_agent_service_path(working_folder)
@@ -253,14 +253,14 @@ def _configure_agent_internal(vsts_url, pat_token, project_name, deployment_grou
     config_url = vsts_url[0:vsts_url.rfind('/')]
     collection = vsts_url[vsts_url.rfind('/'):]
 
-  if(is_byos_agent)
+  if(is_pipelines_agent)
   {
     configure_command_args = ['--url', config_url,
                             '--auth', 'PAT',
                             '--token', pat_token,
                             '--agent', agent_name,
                             '--work', Constants.default_agent_work_dir,
-                            '--pool', byos_pool,
+                            '--pool', pool_name,
                             '--norestart']
   }
   else

--- a/ExtensionHandler/Linux/src/Utils/Constants.py
+++ b/ExtensionHandler/Linux/src/Utils/Constants.py
@@ -2,6 +2,7 @@ agent_setting = '.agent'
 last_seq_num_file = 'LASTSEQNUM'
 download_api_version = '3.0-preview.2'
 agent_working_folder = '/VSTSAgent'
+agent_working_folder_pipelines = '/ElasticPoolAgent'
 update_file_name = 'EXTENSIONUPDATE'
 disable_markup_file_name = 'EXTENSIONDISABLED'
 

--- a/ExtensionHandler/Linux/src/Utils/Constants.py
+++ b/ExtensionHandler/Linux/src/Utils/Constants.py
@@ -2,7 +2,7 @@ agent_setting = '.agent'
 last_seq_num_file = 'LASTSEQNUM'
 download_api_version = '3.0-preview.2'
 agent_working_folder = '/VSTSAgent'
-agent_working_folder_pipelines = '/ElasticPoolAgent'
+agent_working_folder_pipelines = '/Agent'
 update_file_name = 'EXTENSIONUPDATE'
 disable_markup_file_name = 'EXTENSIONDISABLED'
 

--- a/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
@@ -157,6 +157,11 @@ rm_extension_status = {
     'Message': 'Installed the required dependencies',
     'operationName': 'InstallDependencies'
   },
+  'ScheduleRun': {
+    'Code':35,
+    'Message': 'Failed to schedule run',
+    'operationName': 'Schedule Run'
+  }
 
   #
   # Warnings

--- a/ExtensionHandler/Windows/src/Tests/AgentConfigurationManager.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/AgentConfigurationManager.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Agent Configuration Manager Tests" {
     Context "Agent config command without windows user credentials" {
 
         It "should quote arguments containing spaces" {
-            $expectedArgs = "--unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --deploymentgroup --runasservice --projectname `"my proj`" --deploymentgroupname `"my dg`""
+            $expectedArgs = "--unattended --replace --auth PAT  --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --deploymentgroup --runasservice --agent `"my agent`" --projectname `"my proj`" --deploymentgroupname `"my dg`""
             $ret = CreateConfigCmdArgs -tfsUrl "https://acccount.visualstudio.com" -patToken "pat" -workFolder "C:\work folder" -projectName "my proj" -deploymentGroupName "my dg" -agentName "my agent" -windowsLogonAccountName "" -windowsLogonPassword ""
             $ret | Should be $expectedArgs
         }
@@ -15,7 +15,7 @@ Describe "Agent Configuration Manager Tests" {
     Context "Agent config command with windows user credentials" {
 
         It "should quote arguments containing spaces" {
-            $expectedArgs = "--unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --deploymentgroup --runasservice --projectname `"my proj`" --deploymentgroupname `"my dg`" --windowsLogonAccount `"NT AUTHORITY\LOCAL SERVICE`" --windowsLogonPassword `"password`""
+            $expectedArgs = "--unattended --replace --auth PAT  --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --deploymentgroup --runasservice --agent `"my agent`" --projectname `"my proj`" --deploymentgroupname `"my dg`" --windowsLogonAccount `"NT AUTHORITY\LOCAL SERVICE`" --windowsLogonPassword `"password`""
             $ret = CreateConfigCmdArgs -tfsUrl "https://acccount.visualstudio.com" -patToken "pat" -workFolder "C:\work folder" -projectName "my proj" -deploymentGroupName "my dg" -agentName "my agent" -windowsLogonAccountName "NT AUTHORITY\LOCAL SERVICE" -windowsLogonPassword "password"
             $ret | Should be $expectedArgs
         }
@@ -23,7 +23,7 @@ Describe "Agent Configuration Manager Tests" {
 
     Context "Agent config command in Pipelines Agent mode" {
         It "should emit different command-line arguments when Pipelines mode is enabled" {
-            $expectedArgs = "--unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --norestart --pool `"pool`"" 
+            $expectedArgs = "--unattended --replace --auth PAT  --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --norestart --pool `"pool`"" 
             $ret = CreateConfigCmdArgs -tfsUrl "https://acccount.visualstudio.com" -patToken "pat" -workFolder "C:\work folder" -projectName "my proj" -deploymentGroupName "my dg" -agentName "my agent" -isPipelinesAgent $true -poolName "pool"
             $ret | Should be $expectedArgs
         }

--- a/ExtensionHandler/Windows/src/Tests/AgentConfigurationManager.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/AgentConfigurationManager.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Agent Configuration Manager Tests" {
     Context "Agent config command without windows user credentials" {
 
         It "should quote arguments containing spaces" {
-            $expectedArgs = "--deploymentgroup --runasservice --unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --projectname `"my proj`" --deploymentgroupname `"my dg`""
+            $expectedArgs = "--unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --deploymentgroup --runasservice --projectname `"my proj`" --deploymentgroupname `"my dg`""
             $ret = CreateConfigCmdArgs -tfsUrl "https://acccount.visualstudio.com" -patToken "pat" -workFolder "C:\work folder" -projectName "my proj" -deploymentGroupName "my dg" -agentName "my agent" -windowsLogonAccountName "" -windowsLogonPassword ""
             $ret | Should be $expectedArgs
         }
@@ -15,7 +15,7 @@ Describe "Agent Configuration Manager Tests" {
     Context "Agent config command with windows user credentials" {
 
         It "should quote arguments containing spaces" {
-            $expectedArgs = "--deploymentgroup --runasservice --unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --projectname `"my proj`" --deploymentgroupname `"my dg`" --windowsLogonAccount `"NT AUTHORITY\LOCAL SERVICE`" --windowsLogonPassword `"password`""
+            $expectedArgs = "--unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --deploymentgroup --runasservice --projectname `"my proj`" --deploymentgroupname `"my dg`" --windowsLogonAccount `"NT AUTHORITY\LOCAL SERVICE`" --windowsLogonPassword `"password`""
             $ret = CreateConfigCmdArgs -tfsUrl "https://acccount.visualstudio.com" -patToken "pat" -workFolder "C:\work folder" -projectName "my proj" -deploymentGroupName "my dg" -agentName "my agent" -windowsLogonAccountName "NT AUTHORITY\LOCAL SERVICE" -windowsLogonPassword "password"
             $ret | Should be $expectedArgs
         }

--- a/ExtensionHandler/Windows/src/Tests/AgentConfigurationManager.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/AgentConfigurationManager.Tests.ps1
@@ -20,4 +20,12 @@ Describe "Agent Configuration Manager Tests" {
             $ret | Should be $expectedArgs
         }
     }
+
+    Context "Agent config command in Pipelines Agent mode" {
+        It "should emit different command-line arguments when Pipelines mode is enabled" {
+            $expectedArgs = "--unattended --replace --auth PAT  --agent `"my agent`" --url `"https://acccount.visualstudio.com`" --token `"pat`" --work `"C:\work folder`" --norestart --pool `"pool`"" 
+            $ret = CreateConfigCmdArgs -tfsUrl "https://acccount.visualstudio.com" -patToken "pat" -workFolder "C:\work folder" -projectName "my proj" -deploymentGroupName "my dg" -agentName "my agent" -isPipelinesAgent $true -poolName "pool"
+            $ret | Should be $expectedArgs
+        }
+    }
 }

--- a/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
@@ -442,7 +442,7 @@ Describe "BYOS mode should have independent settings from regular deployment" {
             return $inputSettings 
         }
 
-        { Get-ConfigurationFromSettings } | Should -Not -Throw
+        { Get-ConfigurationFromSettings } | Should Not Throw
     }
 
     Context "When BYOS mode is not enabled, pool name is not validated" {
@@ -465,6 +465,6 @@ Describe "BYOS mode should have independent settings from regular deployment" {
             }
             return $inputSettings }
 
-        { Get-ConfigurationFromsettings } | Should -Not -Throw
+        { Get-ConfigurationFromsettings } | Should Not Throw
     }
 }

--- a/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
@@ -421,8 +421,8 @@ Describe "parse tags settings tests" {
     }
 }
 
-Describe "BYOS mode should have independent settings from regular deployment" {
-    Context "When BYOS mode is enabled, pool name is validated and deployment group is not" {
+Describe "Pipelines mode should have independent settings from regular deployment" {
+    Context "When Pipelines mode is enabled, pool name is validated and deployment group is not" {
         Mock Write-Log{}
         Mock Add-HandlerSubStatus {}
         Mock Set-HandlerStatus {}
@@ -447,7 +447,7 @@ Describe "BYOS mode should have independent settings from regular deployment" {
         }
     }
 
-    Context "When BYOS mode is not enabled, pool name is not validated" {
+    Context "When Pipelines mode is not enabled, pool name is not validated" {
         Mock Write-Log{}
         Mock Add-HandlerSubStatus {}
         Mock Set-HandlerStatus {}

--- a/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
@@ -442,7 +442,9 @@ Describe "BYOS mode should have independent settings from regular deployment" {
             return $inputSettings 
         }
 
-        { Get-ConfigurationFromSettings } | Should Not Throw
+        It "should not throw when DeploymentGroup and TeamProject are not provided when IsPipelinesAgent is true" {
+            { Get-ConfigurationFromSettings } | Should Not Throw
+        }
     }
 
     Context "When BYOS mode is not enabled, pool name is not validated" {
@@ -465,6 +467,8 @@ Describe "BYOS mode should have independent settings from regular deployment" {
             }
             return $inputSettings }
 
-        { Get-ConfigurationFromsettings } | Should Not Throw
+        It "should not throw when PoolName is not provided when IsPipelinesAgent is false" {
+            { Get-ConfigurationFromsettings } | Should Not Throw
+        }
     }
 }

--- a/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
@@ -420,3 +420,51 @@ Describe "parse tags settings tests" {
         }
     }
 }
+
+Describe "BYOS mode should have independent settings from regular deployment" {
+    Context "When BYOS mode is enabled, pool name is validated and deployment group is not" {
+        Mock Write-Log{}
+        Mock Add-HandlerSubStatus {}
+        Mock Set-HandlerStatus {}
+        Mock Get-HandlerSettings { 
+            $inputSettings = @{
+                publicSettings =  @{ 
+                        IsBYOSAgent = $true
+                        BYOSPool = "pool"
+                        VSTSAccountName = "tycjfchsdabvdsb"
+                        AgentName = "name" 
+                    };
+                protectedSettings = @{
+                        PATToken = "hash"
+                        Password = "password"
+                }
+            }
+            return $inputSettings 
+        }
+
+        { Get-ConfigurationFromSettings } | Should -Not -Throw
+    }
+
+    Context "When BYOS mode is not enabled, pool name is not validated" {
+        Mock Write-Log{}
+        Mock Add-HandlerSubStatus {}
+        Mock Set-HandlerStatus {}
+        Mock Get-HandlerSettings { 
+            $inputSettings = @{
+                publicSettings =  @{ 
+                        IsBYOSAgent = $false
+                        VSTSAccountName = "tycjfchsdabvdsb"
+                        TeamProject = "project"
+                        DeploymentGroup = "group"
+                        Tags = @()
+                        AgentName = "name" 
+                    };
+                protectedSettings = @{
+                        PATToken = "hash"
+                }
+            }
+            return $inputSettings }
+
+        { Get-ConfigurationFromsettings } | Should -Not -Throw
+    }
+}

--- a/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/ConfigSettingsReader.Tests.ps1
@@ -429,8 +429,8 @@ Describe "BYOS mode should have independent settings from regular deployment" {
         Mock Get-HandlerSettings { 
             $inputSettings = @{
                 publicSettings =  @{ 
-                        IsBYOSAgent = $true
-                        BYOSPool = "pool"
+                        IsPipelinesAgent = $true
+                        PoolName = "pool"
                         VSTSAccountName = "tycjfchsdabvdsb"
                         AgentName = "name" 
                     };
@@ -452,7 +452,7 @@ Describe "BYOS mode should have independent settings from regular deployment" {
         Mock Get-HandlerSettings { 
             $inputSettings = @{
                 publicSettings =  @{ 
-                        IsBYOSAgent = $false
+                        IsPipelinesAgent = $false
                         VSTSAccountName = "tycjfchsdabvdsb"
                         TeamProject = "project"
                         DeploymentGroup = "group"

--- a/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
@@ -231,7 +231,7 @@ Describe "Start RM extension tests" {
         Mock Write-Log {}
         Mock Exit-WithCode {}
         Mock Get-ConfigurationFromSettings {}
-        Mock Test-ExtensionSettingsAreSameAsDisabledVersion {return $true}
+        Mock Test-ExtensionSettingsDoNotPermitEnable {return $true}
         Mock Confirm-InputsAreValid {}
 
         Invoke-PreValidationChecks

--- a/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
@@ -301,6 +301,8 @@ Describe "configure agent tests" {
         Mock ConfigureAgent {}
         
         Register-Agent @{
+            IsBYOSAgent = $false
+            BYOSPool = ""
             AgentWorkingFolder = "AgentWorkingFolder"
             VSTSUrl = "VSTSUrl"
             PATToken = "PATToken"

--- a/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
@@ -14,6 +14,7 @@ Describe "Enable RM extension tests" {
 
         $config = @{
             Tags = @()
+            IsPipelinesAgent = $false
         }
 
     Context "Should save last sequence number file and remove disable mockup file" {
@@ -156,6 +157,7 @@ Describe "Enable RM extension tests" {
         
         $configWithTags = @{
             Tags = @("Tag1")
+            IsPipelinesAgent = $false
         }
         
         Mock Initialize-ExtensionLogFile {}

--- a/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
@@ -301,8 +301,8 @@ Describe "configure agent tests" {
         Mock ConfigureAgent {}
         
         Register-Agent @{
-            IsBYOSAgent = $false
-            BYOSPool = ""
+            IsPipelinesAgent = $false
+            PoolName = ""
             AgentWorkingFolder = "AgentWorkingFolder"
             VSTSUrl = "VSTSUrl"
             PATToken = "PATToken"

--- a/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/enable.Tests.ps1
@@ -231,7 +231,7 @@ Describe "Start RM extension tests" {
         Mock Write-Log {}
         Mock Exit-WithCode {}
         Mock Get-ConfigurationFromSettings {}
-        Mock Test-ExtensionSettingsDoNotPermitEnable {return $true}
+        Mock Test-ExtensionSettingsAreSameAsDisabledVersion {return $true}
         Mock Confirm-InputsAreValid {}
 
         Invoke-PreValidationChecks

--- a/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
+++ b/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
@@ -61,9 +61,9 @@ function ConfigureAgent
     [Parameter(Mandatory=$false)]
     [string]$windowsLogonPassword,
     [Parameter(Mandatory=$false)]
-    [bool]$IsPipelinesAgent,
+    [bool]$isPipelinesAgent,
     [Parameter(Mandatory=$false)]
-    [string]$PoolName
+    [string]$poolName
     )
 
     $configCmdPath = EnsureConfigCmdExists $workingFolder
@@ -76,7 +76,7 @@ function ConfigureAgent
     $processStartInfo.Arguments = CreateConfigCmdArgs -tfsUrl $tfsUrl -patToken $patToken -workFolder $workFolder `
                                  -projectName $projectName -deploymentGroupName $deploymentGroupName -agentName $agentName `
                                  -windowsLogonAccountName $windowsLogonAccountName -windowsLogonPassword $windowsLogonPassword `
-                                 -IsPipelinesAgent $IsPipelinesAgent -PoolName $PoolName
+                                 -IsPipelinesAgent $isPipelinesAgent -PoolName $poolName
     if($global:isOnPrem){
         $processStartInfo.Arguments += " --collectionName $collectionName"
     }
@@ -147,14 +147,14 @@ function CreateConfigCmdArgs
         [string]$agentName,
         [string]$windowsLogonAccountName,
         [string]$windowsLogonPassword,
-        [bool]$IsPipelinesAgent,
-        [string]$PoolName
+        [bool]$isPipelinesAgent,
+        [string]$poolName
     )
 
     $configCmdArgs = "$configCommonArgs --agent `"$agentName`" --url `"$tfsUrl`" --token `"$patToken`" --work `"$workFolder`" "
     
-    if($IsPipelinesAgent){
-        $configCmdArgs += "--norestart --pool `"$PoolName`""
+    if($isPipelinesAgent){
+        $configCmdArgs += "--norestart --pool `"$poolName`""
     }
     else {
         $configCmdArgs += "--deploymentgroup --runasservice --projectname `"$projectName`" --deploymentgroupname `"$deploymentGroupName`""

--- a/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
+++ b/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
@@ -151,13 +151,13 @@ function CreateConfigCmdArgs
         [string]$poolName
     )
 
-    $configCmdArgs = "$configCommonArgs --agent `"$agentName`" --url `"$tfsUrl`" --token `"$patToken`" --work `"$workFolder`" "
+    $configCmdArgs = "$configCommonArgs --url `"$tfsUrl`" --token `"$patToken`" --work `"$workFolder`" "
     
     if($isPipelinesAgent){
         $configCmdArgs += "--norestart --pool `"$poolName`""
     }
     else {
-        $configCmdArgs += "--deploymentgroup --runasservice --projectname `"$projectName`" --deploymentgroupname `"$deploymentGroupName`""
+        $configCmdArgs += "--deploymentgroup --runasservice --agent `"$agentName`" --projectname `"$projectName`" --deploymentgroupname `"$deploymentGroupName`""
     }
     
     if($windowsLogonAccountName){

--- a/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
+++ b/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
@@ -59,7 +59,11 @@ function ConfigureAgent
     [Parameter(Mandatory=$false)]
     [string]$windowsLogonAccountName,
     [Parameter(Mandatory=$false)]
-    [string]$windowsLogonPassword
+    [string]$windowsLogonPassword,
+    [Parameter(Mandatory=$false)]
+    [bool]$isBYOSAgent,
+    [Parameter(Mandatory=$false)]
+    [string]$byosPool
     )
 
     $configCmdPath = EnsureConfigCmdExists $workingFolder
@@ -71,7 +75,8 @@ function ConfigureAgent
     }
     $processStartInfo.Arguments = CreateConfigCmdArgs -tfsUrl $tfsUrl -patToken $patToken -workFolder $workFolder `
                                  -projectName $projectName -deploymentGroupName $deploymentGroupName -agentName $agentName `
-                                 -windowsLogonAccountName $windowsLogonAccountName -windowsLogonPassword $windowsLogonPassword
+                                 -windowsLogonAccountName $windowsLogonAccountName -windowsLogonPassword $windowsLogonPassword `
+                                 -isBYOSAgent $isBYOSAgent -byosPool $byosPool
     if($global:isOnPrem){
         $processStartInfo.Arguments += " --collectionName $collectionName"
     }
@@ -141,10 +146,20 @@ function CreateConfigCmdArgs
         [Parameter(Mandatory=$true)]
         [string]$agentName,
         [string]$windowsLogonAccountName,
-        [string]$windowsLogonPassword
+        [string]$windowsLogonPassword,
+        [bool]$isBYOSAgent,
+        [string]$byosPool
     )
 
-    $configCmdArgs = "$configCommonArgs --agent `"$agentName`" --url `"$tfsUrl`" --token `"$patToken`" --work `"$workFolder`" --projectname `"$projectName`" --deploymentgroupname `"$deploymentGroupName`""
+    $configCmdArgs = "$configCommonArgs --agent `"$agentName`" --url `"$tfsUrl`" --token `"$patToken`" --work `"$workFolder`" "
+    
+    if($isBYOSAgent){
+        $configCmdArgs += "--norestart --pool `"$byosPool`""
+    }
+    else {
+        $configCmdArgs += "--deploymentgroup --runasservice --projectname `"$projectName`" --deploymentgroupname `"$deploymentGroupName`""
+    }
+    
     if($windowsLogonAccountName){
         $configCmdArgs += " --windowsLogonAccount `"$windowsLogonAccountName`" --windowsLogonPassword `"$windowsLogonPassword`""
     }

--- a/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
+++ b/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
@@ -61,9 +61,9 @@ function ConfigureAgent
     [Parameter(Mandatory=$false)]
     [string]$windowsLogonPassword,
     [Parameter(Mandatory=$false)]
-    [bool]$isBYOSAgent,
+    [bool]$IsPipelinesAgent,
     [Parameter(Mandatory=$false)]
-    [string]$byosPool
+    [string]$PoolName
     )
 
     $configCmdPath = EnsureConfigCmdExists $workingFolder
@@ -76,7 +76,7 @@ function ConfigureAgent
     $processStartInfo.Arguments = CreateConfigCmdArgs -tfsUrl $tfsUrl -patToken $patToken -workFolder $workFolder `
                                  -projectName $projectName -deploymentGroupName $deploymentGroupName -agentName $agentName `
                                  -windowsLogonAccountName $windowsLogonAccountName -windowsLogonPassword $windowsLogonPassword `
-                                 -isBYOSAgent $isBYOSAgent -byosPool $byosPool
+                                 -IsPipelinesAgent $IsPipelinesAgent -PoolName $PoolName
     if($global:isOnPrem){
         $processStartInfo.Arguments += " --collectionName $collectionName"
     }
@@ -147,14 +147,14 @@ function CreateConfigCmdArgs
         [string]$agentName,
         [string]$windowsLogonAccountName,
         [string]$windowsLogonPassword,
-        [bool]$isBYOSAgent,
-        [string]$byosPool
+        [bool]$IsPipelinesAgent,
+        [string]$PoolName
     )
 
     $configCmdArgs = "$configCommonArgs --agent `"$agentName`" --url `"$tfsUrl`" --token `"$patToken`" --work `"$workFolder`" "
     
-    if($isBYOSAgent){
-        $configCmdArgs += "--norestart --pool `"$byosPool`""
+    if($IsPipelinesAgent){
+        $configCmdArgs += "--norestart --pool `"$PoolName`""
     }
     else {
         $configCmdArgs += "--deploymentgroup --runasservice --projectname `"$projectName`" --deploymentgroupname `"$deploymentGroupName`""

--- a/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
+++ b/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
@@ -76,7 +76,7 @@ function ConfigureAgent
     $processStartInfo.Arguments = CreateConfigCmdArgs -tfsUrl $tfsUrl -patToken $patToken -workFolder $workFolder `
                                  -projectName $projectName -deploymentGroupName $deploymentGroupName -agentName $agentName `
                                  -windowsLogonAccountName $windowsLogonAccountName -windowsLogonPassword $windowsLogonPassword `
-                                 -isPipelinesAgent $isPipelinesAgent -poolName $poolName
+                                 -IsPipelinesAgent $isPipelinesAgent -PoolName $poolName
     if($global:isOnPrem){
         $processStartInfo.Arguments += " --collectionName $collectionName"
     }

--- a/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
+++ b/ExtensionHandler/Windows/src/bin/AgentConfigurationManager.ps1
@@ -76,7 +76,7 @@ function ConfigureAgent
     $processStartInfo.Arguments = CreateConfigCmdArgs -tfsUrl $tfsUrl -patToken $patToken -workFolder $workFolder `
                                  -projectName $projectName -deploymentGroupName $deploymentGroupName -agentName $agentName `
                                  -windowsLogonAccountName $windowsLogonAccountName -windowsLogonPassword $windowsLogonPassword `
-                                 -IsPipelinesAgent $isPipelinesAgent -PoolName $poolName
+                                 -isPipelinesAgent $isPipelinesAgent -poolName $poolName
     if($global:isOnPrem){
         $processStartInfo.Arguments += " --collectionName $collectionName"
     }

--- a/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
+++ b/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
@@ -52,22 +52,22 @@ function Get-ConfigurationFromSettings {
         }
         
         #Extract and verify public settings
-        $IsPipelinesAgent = $false;
+        $isPipelinesAgent = $false;
         if($publicSettings.Contains('IsPipelinesAgent'))
         {
             Write-Log "Configured as a Pipelines Agent"
-            $IsPipelinesAgent = $publicSettings['IsPipelinesAgent']
+            $isPipelinesAgent = $publicSettings['IsPipelinesAgent']
         }
 
-        $PoolName = ""
+        $poolName = ""
         if($publicSettings.Contains('PoolName'))
         {
-            $PoolName = $publicSettings['PoolName']
+            $poolName = $publicSettings['PoolName']
         }
-        if($IsPipelinesAgent)
+        if($isPipelinesAgent)
         {
-            Verify-InputNotNull "PoolName" $PoolName
-            Write-Log "Pool Name: $PoolName"
+            Verify-InputNotNull "PoolName" $poolName
+            Write-Log "Pool Name: $poolName"
         }
 
         $vstsAccountUrl = ""
@@ -89,7 +89,7 @@ function Get-ConfigurationFromSettings {
         Write-Log "Azure DevOps Organization Url: $vstsUrl"
 
         $teamProjectName = $publicSettings['TeamProject']
-        if(-not $IsPipelinesAgent)
+        if(-not $isPipelinesAgent)
         {
             Verify-InputNotNull "TeamProject" $teamProjectName
             Write-Log "Team Project: $teamProjectName"
@@ -100,7 +100,7 @@ function Get-ConfigurationFromSettings {
         {
             $deploymentGroupName = $publicSettings['MachineGroup']
         }
-        if(-not $IsPipelinesAgent)
+        if(-not $isPipelinesAgent)
         {
             Verify-InputNotNull "DeploymentGroup" $deploymentGroupName
             Write-Log "Deployment Group: $deploymentGroupName"
@@ -147,8 +147,8 @@ function Get-ConfigurationFromSettings {
             Tags               = $tags
             WindowsLogonAccountName = $windowsLogonAccountName
             WindowsLogonPassword = $windowsLogonPassword
-            IsPipelinesAgent = $IsPipelinesAgent
-            PoolName = $PoolName
+            IsPipelinesAgent = $isPipelinesAgent
+            PoolName = $poolName
         }
     }
     catch

--- a/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
+++ b/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
@@ -67,6 +67,7 @@ function Get-ConfigurationFromSettings {
         {
             Write-Log "Configured as a BYOS Agent"
             Verify-InputNotNull "BYOSPool" $byosPool
+            Write-Log "BYOS Pool: $byosPool"
         }
 
         $vstsAccountUrl = ""

--- a/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
+++ b/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
@@ -51,23 +51,23 @@ function Get-ConfigurationFromSettings {
             $windowsLogonPassword = $protectedSettings['Password']
         }
         
-        #Extract and verify public 
-        $isBYOSAgent = $false;
-        if($publicSettings.Contains('IsBYOSAgent'))
-        {
-            $isBYOSAgent = $publicSettings['IsBYOSAgent']
-        }
-
-        $byosPool = ""
-        if($publicSettings.Contains('BYOSPool'))
-        {
-            $byosPool = $publicSettings['BYOSPool']
-        }
-        if($isBYOSAgent)
+        #Extract and verify public settings
+        $IsPipelinesAgent = $false;
+        if($publicSettings.Contains('IsPipelinesAgent'))
         {
             Write-Log "Configured as a BYOS Agent"
-            Verify-InputNotNull "BYOSPool" $byosPool
-            Write-Log "BYOS Pool: $byosPool"
+            $IsPipelinesAgent = $publicSettings['IsPipelinesAgent']
+        }
+
+        $PoolName = ""
+        if($publicSettings.Contains('PoolName'))
+        {
+            $PoolName = $publicSettings['PoolName']
+        }
+        if($IsPipelinesAgent)
+        {
+            Verify-InputNotNull "PoolName" $PoolName
+            Write-Log "BYOS Pool: $PoolName"
         }
 
         $vstsAccountUrl = ""
@@ -89,7 +89,7 @@ function Get-ConfigurationFromSettings {
         Write-Log "Azure DevOps Organization Url: $vstsUrl"
 
         $teamProjectName = $publicSettings['TeamProject']
-        if(-not $isBYOSAgent)
+        if(-not $IsPipelinesAgent)
         {
             Verify-InputNotNull "TeamProject" $teamProjectName
             Write-Log "Team Project: $teamProjectName"
@@ -100,7 +100,7 @@ function Get-ConfigurationFromSettings {
         {
             $deploymentGroupName = $publicSettings['MachineGroup']
         }
-        if(-not $isBYOSAgent)
+        if(-not $IsPipelinesAgent)
         {
             Verify-InputNotNull "DeploymentGroup" $deploymentGroupName
             Write-Log "Deployment Group: $deploymentGroupName"
@@ -147,8 +147,8 @@ function Get-ConfigurationFromSettings {
             Tags               = $tags
             WindowsLogonAccountName = $windowsLogonAccountName
             WindowsLogonPassword = $windowsLogonPassword
-            IsBYOSAgent = $isBYOSAgent
-            BYOSPool = $byosPool
+            IsPipelinesAgent = $IsPipelinesAgent
+            PoolName = $PoolName
         }
     }
     catch
@@ -166,8 +166,9 @@ function Confirm-InputsAreValid {
 
     #If the agent is being added as a BYOS agent, then no deployment group will be specified.
     #It is not necessary to validate the deployment group inputs.
-    if ($config.IsBYOSAgent)
+    if ($config.IsPipelinesAgent)
     {
+        Write-Log "Skipping input validation because this is a BYOS agent."
         return;
     }
 

--- a/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
+++ b/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
@@ -633,3 +633,27 @@ function Verify-InputNotNull {
             throw New-HandlerTerminatingError $RM_Extension_Status.InputConfigurationError -Message $message
         }
 }
+
+function Get-AgentWorkingFolder {
+    [CmdletBinding()]
+    param()
+
+    . $PSScriptRoot\AgentSettingsHelper.ps1
+    . $PSScriptRoot\Constants.ps1
+
+    $config = Get-ConfigurationFromSettings
+
+    if($config.IsPipelinesAgent)
+    {
+        return $agentWorkingFolderPipelines
+    }
+
+    if(!(Test-ConfiguredAgentExists -workingFolder $agentWorkingFolderNew))
+    {
+        if(Test-ConfiguredAgentExists -workingFolder $agentWorkingFolderOld)
+        {
+            return $agentWorkingFolderOld
+        }
+    }
+    return $agentWorkingFolderNew
+}

--- a/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
+++ b/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
@@ -70,6 +70,12 @@ function Get-ConfigurationFromSettings {
             Write-Log "Pool Name: $poolName"
         }
 
+        $singleUse = $false
+        if($publicSettings.Contains('SingleUse'))
+        {
+            $singleUse = $publicSettings['SingleUse']
+        }
+
         $vstsAccountUrl = ""
         if($publicSettings.Contains('AzureDevOpsOrganizationUrl'))
         {
@@ -149,6 +155,7 @@ function Get-ConfigurationFromSettings {
             WindowsLogonPassword = $windowsLogonPassword
             IsPipelinesAgent = $isPipelinesAgent
             PoolName = $poolName
+            SingleUse = $singleUse
         }
     }
     catch

--- a/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
+++ b/ExtensionHandler/Windows/src/bin/ConfigSettingsReader.ps1
@@ -55,7 +55,7 @@ function Get-ConfigurationFromSettings {
         $IsPipelinesAgent = $false;
         if($publicSettings.Contains('IsPipelinesAgent'))
         {
-            Write-Log "Configured as a BYOS Agent"
+            Write-Log "Configured as a Pipelines Agent"
             $IsPipelinesAgent = $publicSettings['IsPipelinesAgent']
         }
 
@@ -67,7 +67,7 @@ function Get-ConfigurationFromSettings {
         if($IsPipelinesAgent)
         {
             Verify-InputNotNull "PoolName" $PoolName
-            Write-Log "BYOS Pool: $PoolName"
+            Write-Log "Pool Name: $PoolName"
         }
 
         $vstsAccountUrl = ""
@@ -164,11 +164,11 @@ function Confirm-InputsAreValid {
     [hashtable] $config
     )
 
-    #If the agent is being added as a BYOS agent, then no deployment group will be specified.
+    #If the agent is being added as a Pipelines agent, then no deployment group will be specified.
     #It is not necessary to validate the deployment group inputs.
     if ($config.IsPipelinesAgent)
     {
-        Write-Log "Skipping input validation because this is a BYOS agent."
+        Write-Log "Skipping input validation because this is a Pipelines agent."
         return;
     }
 

--- a/ExtensionHandler/Windows/src/bin/Constants.ps1
+++ b/ExtensionHandler/Windows/src/bin/Constants.ps1
@@ -11,7 +11,7 @@ $defaultAgentWorkFolder = "_work"
 $platform = "win-x64"
 $agentWorkingFolderOld = "$env:SystemDrive\VSTSAgent"
 $agentWorkingFolderNew = "$env:SystemDrive\AzurePiplinesAgent_Extension"
-$agentWorkingFolderPipelines = "$env:SystemDrive\ElasticPoolAgent"
+$agentWorkingFolderPipelines = "$env:SystemDrive\Agent"
 $agentNameCharacterLimit = 64
 
 # markup files

--- a/ExtensionHandler/Windows/src/bin/Constants.ps1
+++ b/ExtensionHandler/Windows/src/bin/Constants.ps1
@@ -11,6 +11,7 @@ $defaultAgentWorkFolder = "_work"
 $platform = "win-x64"
 $agentWorkingFolderOld = "$env:SystemDrive\VSTSAgent"
 $agentWorkingFolderNew = "$env:SystemDrive\AzurePiplinesAgent_Extension"
+$agentWorkingFolderPipelines = "$env:SystemDrive\ElasticPoolAgent"
 $agentNameCharacterLimit = 64
 
 # markup files

--- a/ExtensionHandler/Windows/src/bin/Constants.ps1
+++ b/ExtensionHandler/Windows/src/bin/Constants.ps1
@@ -5,7 +5,7 @@ $apiVersion = "5.0-preview.1"
 
 $agentZipName = "agent.zip"
 $configCmd = "config.cmd"
-$configCommonArgs = "--deploymentgroup --runasservice --unattended --replace --auth PAT "
+$configCommonArgs = "--unattended --replace --auth PAT "
 $removeAgentArgs = " remove --unattended --auth PAT "
 $defaultAgentWorkFolder = "_work"
 $platform = "win-x64"

--- a/ExtensionHandler/Windows/src/bin/RMExtensionCommon.psm1
+++ b/ExtensionHandler/Windows/src/bin/RMExtensionCommon.psm1
@@ -16,31 +16,6 @@ Import-Module $PSScriptRoot\RMExtensionStatus.psm1
 Import-Module $PSScriptRoot\Log.psm1
 . "$PSScriptRoot\RMExtensionUtilities.ps1"
 . "$PSScriptRoot\AgentConfigurationManager.ps1"
-. "$PSScriptRoot\ConfigSettingsReader.ps1"
-
-function Get-AgentWorkingFolder {
-    [CmdletBinding()]
-    param()
-
-    . $PSScriptRoot\AgentSettingsHelper.ps1
-    . $PSScriptRoot\Constants.ps1
-
-    $config = Get-ConfigurationFromSettings
-
-    if($config.IsPipelinesAgent)
-    {
-        return $agentWorkingFolderPipelines
-    }
-
-    if(!(Test-ConfiguredAgentExists -workingFolder $agentWorkingFolderNew))
-    {
-        if(Test-ConfiguredAgentExists -workingFolder $agentWorkingFolderOld)
-        {
-            return $agentWorkingFolderOld
-        }
-    }
-    return $agentWorkingFolderNew
-}
 
 <#
 .Synopsis

--- a/ExtensionHandler/Windows/src/bin/RMExtensionCommon.psm1
+++ b/ExtensionHandler/Windows/src/bin/RMExtensionCommon.psm1
@@ -16,6 +16,7 @@ Import-Module $PSScriptRoot\RMExtensionStatus.psm1
 Import-Module $PSScriptRoot\Log.psm1
 . "$PSScriptRoot\RMExtensionUtilities.ps1"
 . "$PSScriptRoot\AgentConfigurationManager.ps1"
+. "$PSScriptRoot\ConfigSettingsReader.ps1"
 
 function Get-AgentWorkingFolder {
     [CmdletBinding()]
@@ -23,6 +24,13 @@ function Get-AgentWorkingFolder {
 
     . $PSScriptRoot\AgentSettingsHelper.ps1
     . $PSScriptRoot\Constants.ps1
+
+    $config = Get-ConfigurationFromSettings
+
+    if($config.IsPipelinesAgent)
+    {
+        return $agentWorkingFolderPipelines
+    }
 
     if(!(Test-ConfiguredAgentExists -workingFolder $agentWorkingFolderNew))
     {

--- a/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
+++ b/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
@@ -173,6 +173,12 @@ $global:RM_Extension_Status = @{
         operationName = 'Inputs validation'
     }
 
+    ScheduledRunFailed = @{
+        Code = 32
+        Message = 'Failed to schedule run'
+        operationName = 'Schedule Run'
+    }
+
     #
     # Warnings
     #

--- a/ExtensionHandler/Windows/src/bin/disable.ps1
+++ b/ExtensionHandler/Windows/src/bin/disable.ps1
@@ -17,6 +17,7 @@ Import-Module $PSScriptRoot\AzureExtensionHandler.psm1
 Import-Module $PSScriptRoot\RMExtensionCommon.psm1 -DisableNameChecking
 Import-Module $PSScriptRoot\RMExtensionStatus.psm1
 Import-Module $PSScriptRoot\Log.psm1
+. $PSScriptRoot\ConfigSettingsReader.ps1
 
 Initialize-ExtensionLogFile
 

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -303,6 +303,10 @@ function Test-ExtensionSettingsDoNotPermitEnable
 
             if($oldIsPipelinesAgent -ne $newIsPipelinesAgent)
             {
+                Write-Log "Disabled version settings and new version settings differ on IsPipelinesAgent setting." $true
+                Write-Log "Switching between Deployment and Pipelines Agent is not permitted." $true
+                Write-Log "Disabled version settings: $($oldExtensionPublicSettings | ConvertTo-Json)" $true
+                Write-Log "New version settings: $($extensionPublicSettings | ConvertTo-Json)" $true
                 return $true
             }
 

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -267,7 +267,7 @@ function Add-AgentTags
     }
 }
 
-function Test-ExtensionSettingsDoNotPermitEnable
+function Test-ExtensionSettingsAreSameAsDisabledVersion
 {
     [CmdletBinding()]
     param(
@@ -285,31 +285,6 @@ function Test-ExtensionSettingsDoNotPermitEnable
             $oldExtensionPublicSettings = (Get-ExtensionDisabledMarkup $config.AgentWorkingFolder).runtimeSettings[0].handlerSettings.publicSettings
             $extensionPublicSettings = (Get-JsonContent $extensionSettingsFilePath).runtimeSettings[0].handlerSettings.publicSettings
             $settingsSame = $false
-
-            #A deployment agent should not be reconfigured as a Pipelines agent, and vice-versa.
-            #Therefore, check if the settings are the same between both copies of the public settings
-            #(with not present = $false) and return true (do not enable) if their values do not match.
-            $oldIsPipelinesAgent = $false
-            if($oldExtensionPublicSettings.Contains('IsPipelinesAgent'))
-            {
-                $oldIsPipelinesAgent = $oldExtensionPublicSettings['IsPipelinesAgent']
-            }
-
-            $newIsPipelinesAgent = $false
-            if($extensionPublicSettings.Contains('IsPipelinesAgent'))
-            {
-                $newIsPipelinesAgent = $extensionPublicSettings['IsPipelinesAgent']
-            }
-
-            if($oldIsPipelinesAgent -ne $newIsPipelinesAgent)
-            {
-                Write-Log "Disabled version settings and new version settings differ on IsPipelinesAgent setting." $true
-                Write-Log "Switching between Deployment and Pipelines Agent is not permitted." $true
-                Write-Log "Disabled version settings: $($oldExtensionPublicSettings | ConvertTo-Json)" $true
-                Write-Log "New version settings: $($extensionPublicSettings | ConvertTo-Json)" $true
-                return $true
-            }
-
             if($oldExtensionPublicSettings.Keys.Count -eq $extensionPublicSettings.Keys.Count)
             {
                 $settingsSame = $true
@@ -465,8 +440,8 @@ function Enable
     $config = Get-ConfigurationFromSettings
     $config.AgentWorkingFolder = Get-AgentWorkingFolder
     Compare-SequenceNumber $config
-    $skipEnable = Test-ExtensionSettingsDoNotPermitEnable $config
-    if($skipEnable)
+    $settingsAreSame = Test-ExtensionSettingsAreSameAsDisabledVersion $config
+    if($settingsAreSame)
     {
         Write-Log "Skipping extension enable."
         Add-HandlerSubStatus $RM_Extension_Status.SkippingEnableSameSettingsAsDisabledVersion.Code $RM_Extension_Status.SkippingEnableSameSettingsAsDisabledVersion.Message -operationName $RM_Extension_Status.SkippingEnableSameSettingsAsDisabledVersion.operationName

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -459,7 +459,10 @@ function Enable
         ConfigureAgentIfRequired $config
         Set-HandlerStatus $RM_Extension_Status.Installed.Code $RM_Extension_Status.Installed.Message
 
-        Add-AgentTags $config
+        if(-not $config.IsPipelinesAgent)
+        {
+            Add-AgentTags $config
+        }
 
         Write-Log "Extension is enabled."
     }

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -135,7 +135,7 @@ function Register-Agent {
         Validate-AgentName $config
         ConfigureAgent -tfsUrl $config.VSTSUrl -patToken $config.PATToken -workFolder $defaultAgentWorkFolder -projectName $config.TeamProject -deploymentGroupName $config.DeploymentGroup -agentName $config.AgentName `
         -workingFolder $config.AgentWorkingFolder -windowsLogonAccountName $config.WindowsLogonAccountName -windowsLogonPassword $config.WindowsLogonPassword `
-        -IsPipelinesAgent $config.IsPipelinesAgent -PoolName $config.PoolName
+        -isPipelinesAgent $config.IsPipelinesAgent -poolName $config.PoolName
 
         Write-Log "Agent configured successfully" $true
 

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -134,7 +134,8 @@ function Register-Agent {
         
         Validate-AgentName $config
         ConfigureAgent -tfsUrl $config.VSTSUrl -patToken $config.PATToken -workFolder $defaultAgentWorkFolder -projectName $config.TeamProject -deploymentGroupName $config.DeploymentGroup -agentName $config.AgentName `
-        -workingFolder $config.AgentWorkingFolder -windowsLogonAccountName $config.WindowsLogonAccountName -windowsLogonPassword $config.WindowsLogonPassword
+        -workingFolder $config.AgentWorkingFolder -windowsLogonAccountName $config.WindowsLogonAccountName -windowsLogonPassword $config.WindowsLogonPassword `
+        -isBYOSAgent $config.IsBYOSAgent -byosPool $config.BYOSPool
 
         Write-Log "Agent configured successfully" $true
 

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -135,7 +135,7 @@ function Register-Agent {
         Validate-AgentName $config
         ConfigureAgent -tfsUrl $config.VSTSUrl -patToken $config.PATToken -workFolder $defaultAgentWorkFolder -projectName $config.TeamProject -deploymentGroupName $config.DeploymentGroup -agentName $config.AgentName `
         -workingFolder $config.AgentWorkingFolder -windowsLogonAccountName $config.WindowsLogonAccountName -windowsLogonPassword $config.WindowsLogonPassword `
-        -isBYOSAgent $config.IsBYOSAgent -byosPool $config.BYOSPool
+        -IsPipelinesAgent $config.IsPipelinesAgent -PoolName $config.PoolName
 
         Write-Log "Agent configured successfully" $true
 

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -206,6 +206,16 @@ function Compare-SequenceNumber{
         #
         $sequenceNumber = Get-HandlerExecutionSequenceNumber
         $lastSequenceNumber = Get-LastSequenceNumber
+
+        if($config.IsPipelinesAgent -and ($lastSequenceNumber -ne -1) -and ($sequenceNumber -gt $lastSequenceNumber))
+        {
+            Write-Log $RM_Extension_Status.SkippedInstallation.Message
+            Write-Log "Skipping enable since a Pipelines Agent may only install once. Seq number: $sequenceNumber. Last Seq Number: $lastSequenceNumber."
+            Add-HandlerSubStatus $RM_Extension_Status.SkippedInstallation.Code $RM_Extension_Status.SkippedInstallation.Message -operationName $RM_Extension_Status.SkippedInstallation.operationName
+            Set-HandlerStatus $RM_Extension_Status.Enabled.Code $RM_Extension_Status.Enabled.Message -Status success
+            Exit-WithCode 0
+        }
+
         if(($sequenceNumber -eq $lastSequenceNumber) -and (!(Test-ExtensionDisabledMarkup $config.AgentWorkingFolder)))
         {
             Write-Log $RM_Extension_Status.SkippedInstallation.Message

--- a/ExtensionHandler/Windows/src/bin/enable.ps1
+++ b/ExtensionHandler/Windows/src/bin/enable.ps1
@@ -460,10 +460,16 @@ function Enable
     {
         Confirm-InputsAreValid $config
 
-        ExecuteAgentPreCheck $config
+        if(-not $config.IsPipelinesAgent)
+        {
+            ExecuteAgentPreCheck $config
+        }
 
-        RemoveExistingAgentIfRequired $config
-
+        if(-not $config.IsPipelinesAgent)
+        {
+            RemoveExistingAgentIfRequired $config
+        }
+        
         DownloadAgentIfRequired $config
 
         ConfigureAgentIfRequired $config

--- a/ExtensionHandler/Windows/src/bin/uninstall.ps1
+++ b/ExtensionHandler/Windows/src/bin/uninstall.ps1
@@ -16,6 +16,7 @@ Import-Module $PSScriptRoot\RMExtensionStatus.psm1
 Import-Module $PSScriptRoot\Log.psm1
 . $PSScriptRoot\AgentSettingsHelper.ps1
 . $PSScriptRoot\Constants.ps1
+. $PSScriptRoot\ConfigSettingsReader.ps1
 
 Initialize-ExtensionLogFile
 

--- a/ExtensionHandler/Windows/src/bin/update.ps1
+++ b/ExtensionHandler/Windows/src/bin/update.ps1
@@ -12,6 +12,7 @@ if (!(Test-Path variable:PSScriptRoot) -or !($PSScriptRoot)) { # $PSScriptRoot i
 
 Import-Module $PSScriptRoot\AzureExtensionHandler.psm1
 Import-Module $PSScriptRoot\RMExtensionCommon.psm1 -DisableNameChecking
+. $PSScriptRoot\ConfigSettingsReader.ps1
 
 #Not logging in update, because config settings are not yet received in update, and 
 #the log file logic requrires the sequence number.


### PR DESCRIPTION
The full spec sheet / design doc for this feature can be found on the AzureDevOps.Docs repository, under the branch users/wireznak/vsts-azure-extension-proposal, file path /Pipelines/BYOS/vsts-azureextension-modification-spec.md.

We wish to avoid using the Custom Script Extension to install the build agent software on virtual machines submitted to us through BYOS, because the customer may want to use this extension for their own purposes and Virtual Machine Scale Sets may only have one copy of each unique type of Azure Extension. Instead, we will re-use the existing Azure Pipelines Agent extension, using a special setting to configure the build agent to connect to the Elastic Pool. This entails the following:

- A flag value IsPipelinesAgent that activates the new code branch.
- A string value PoolName that gives the name of the pool to which the agent should connect.
- New code branches in the validation steps to selectively validate the settings based on which settings are relevant to the current mode.
- Logging to track when we're in "Pipelines mode".
- Different command-line arguments will be used to configure the agent software depending on whether "pipelines mode" is enabled.
- New unit tests to confirm the above behaviors.

