### PR TITLE
Make elastic pool logic async - Linux

### DIFF
--- a/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.22.0.0</Version>
+    <Version>1.23.0.0</Version>
     <Label>Team Services Agent For Linux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for linux machine group machines</Description>

--- a/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
     <ProviderNameSpace>Test.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.149.0.0</Version>
+    <Version>1.150.0.0</Version>
     <Label>TeamServicesAgentLinux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>VSTS agent for machine groups</Description>

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -569,7 +569,7 @@ def test_extension_settings_are_same_as_disabled_version():
 
 def enable_pipelines_agent(config):
   try:
-
+    sleep(360) ## Keeping it here just for the testing
     handler_utility.log('Enable Pipelines Agent')
 
     # verify we have the enable script parameters here.
@@ -669,8 +669,14 @@ def enable():
   pre_validation_checks()
   config = get_configuration_from_settings()
   if(config.get('IsPipelinesAgent') != None):
-    enable_pipelines_agent(config)
-    return
+    pid = os.fork()
+    if(pid > 0):
+      handler_utility.log('Exiting parent process with PID: ' + str(pid))
+      return
+    else:
+      handler_utility.log('Spawned child process with PID: ' + str(os.getpid()))
+      enable_pipelines_agent(config)
+      return
 
   settings_are_same = test_extension_settings_are_same_as_disabled_version()
   if(settings_are_same):

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -671,7 +671,7 @@ def enable():
   if(config.get('IsPipelinesAgent') != None):
     pid = os.fork()
     if(pid > 0):
-      handler_utility.log('Exiting parent process with PID: ' + str(pid))
+      handler_utility.log('Exiting parent process with PID: ' + str(os.getpid()))
       return
     else:
       handler_utility.log('Spawned child process with PID: ' + str(os.getpid()))

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -569,7 +569,6 @@ def test_extension_settings_are_same_as_disabled_version():
 
 def enable_pipelines_agent(config):
   try:
-    sleep(360) ## Keeping it here just for the testing
     handler_utility.log('Enable Pipelines Agent')
 
     # verify we have the enable script parameters here.

--- a/ExtensionHandler/Linux/src/AzureRM_python2.py
+++ b/ExtensionHandler/Linux/src/AzureRM_python2.py
@@ -640,7 +640,7 @@ def enable():
   if(config.get('IsPipelinesAgent') != None):
     pid = os.fork()
     if(pid > 0):
-      handler_utility.log('Exiting parent process with PID: ' + str(pid))
+      handler_utility.log('Exiting parent process with PID: ' + str(os.getpid()))
       return
     else:
       handler_utility.log('Spawned child process with PID: ' + str(os.getpid()))

--- a/ExtensionHandler/Linux/src/AzureRM_python2.py
+++ b/ExtensionHandler/Linux/src/AzureRM_python2.py
@@ -638,7 +638,13 @@ def enable():
   pre_validation_checks()
   config = get_configuration_from_settings()
   if(config.get('IsPipelinesAgent') != None):
-    enable_pipelines_agent(config)
+    pid = os.fork()
+    if(pid > 0):
+      handler_utility.log('Exiting parent process with PID: ' + str(pid))
+      return
+    else:
+      handler_utility.log('Spawned child process with PID: ' + str(os.getpid()))
+      enable_pipelines_agent(config)
     return
 
   settings_are_same = test_extension_settings_are_same_as_disabled_version()


### PR DESCRIPTION
Changes to make elastic pool logic async and avoid stuck extensions in transitioning state. Some times dependencies take more than 5 minutes to install, when that happens the process gets killed by waagent. By spawning a different process we ensure that we will be able to update the extension status when it takes more than 5 minutes to complete.

At the moment the PR only contains changes for Linux, we will also need to do the same changes for Windows.