### PR TITLE
Users/tiantun/1995677 skip enable if already configured

### DIFF
--- a/ExtensionHandler/Windows/ExtensionDefinition_Prod_MIGRATED.xml
+++ b/ExtensionHandler/Windows/ExtensionDefinition_Prod_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgent</Type>
-    <Version>1.29.0.0</Version>
+    <Version>1.31.0.0</Version>
     <Label>Team Services Agent</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for machine groups</Description>

--- a/ExtensionHandler/Windows/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Windows/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Test3.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgent</Type>
-    <Version>1.79.0.0</Version>
+    <Version>1.81.0.0</Version>
     <Label>Team Services Agent</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for machine groups</Description>

--- a/ExtensionHandler/Windows/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Windows/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Test3.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgent</Type>
-    <Version>1.81.0.0</Version>
+    <Version>1.82.0.0</Version>
     <Label>Team Services Agent</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for machine groups</Description>

--- a/ExtensionHandler/Windows/src/bin/EnablePipelinesAgent.ps1
+++ b/ExtensionHandler/Windows/src/bin/EnablePipelinesAgent.ps1
@@ -28,9 +28,8 @@ function EnablePipelinesAgent
         }
 
         # First check if we've already executed and configured the agent
-        $autologonFile = Join-Path -Path $config.AgentFolder -ChildPath ".autologon"
-        $contents = Get-Content $autologonFile -ErrorAction Ignore
-        if ($contents -like '*AzDevOps*')
+        $agentConfigFile = Join-Path -Path $config.AgentFolder -ChildPath ".agent"
+        if (Test-Path -Path $agentConfigFile)
         {
             Write-Log "Already configured.  Marking extension as successful."
             Add-HandlerSubStatus $RM_Extension_Status.RebootedPipelinesAgent.Code $RM_Extension_Status.RebootedPipelinesAgent.Message -operationName $RM_Extension_Status.RebootedPipelinesAgent.operationName
@@ -158,6 +157,7 @@ function EnablePipelinesAgent
 
         Add-HandlerSubStatus $RM_Extension_Status.EnablePipelinesAgentSuccess.Code $log -operationName $RM_Extension_Status.EnablePipelinesAgentSuccess.operationName
         Set-HandlerStatus $RM_Extension_Status.Enabled.Code $RM_Extension_Status.Enabled.Message -Status success
+        Set-LastSequenceNumber
         Exit-WithCode 0
     }
     catch

--- a/ExtensionHandler/Windows/src/bin/EnablePipelinesAgent.ps1
+++ b/ExtensionHandler/Windows/src/bin/EnablePipelinesAgent.ps1
@@ -32,7 +32,7 @@ function EnablePipelinesAgent
         if (Test-Path -Path $agentConfigFile)
         {
             Write-Log "Already configured.  Marking extension as successful."
-            Add-HandlerSubStatus $RM_Extension_Status.RebootedPipelinesAgent.Code $RM_Extension_Status.RebootedPipelinesAgent.Message -operationName $RM_Extension_Status.RebootedPipelinesAgent.operationName
+            Add-HandlerSubStatus $RM_Extension_Status.PipelinesAgentAlreadyConfigured.Code $RM_Extension_Status.PipelinesAgentAlreadyConfigured.Message -operationName $RM_Extension_Status.PipelinesAgentAlreadyConfigured.operationName
             Set-HandlerStatus $RM_Extension_Status.Enabled.Code $RM_Extension_Status.Enabled.Message -Status success
             Exit-WithCode 0
             return

--- a/ExtensionHandler/Windows/src/bin/EnablePipelinesAgent.ps1
+++ b/ExtensionHandler/Windows/src/bin/EnablePipelinesAgent.ps1
@@ -31,8 +31,8 @@ function EnablePipelinesAgent
         $agentConfigFile = Join-Path -Path $config.AgentFolder -ChildPath ".agent"
         if (Test-Path -Path $agentConfigFile)
         {
-            Write-Log "Already configured.  Marking extension as successful."
-            Add-HandlerSubStatus $RM_Extension_Status.PipelinesAgentAlreadyConfigured.Code $RM_Extension_Status.PipelinesAgentAlreadyConfigured.Message -operationName $RM_Extension_Status.PipelinesAgentAlreadyConfigured.operationName
+            Write-Log "Agent already enabled. Skipping."
+            Add-HandlerSubStatus $RM_Extension_Status.AgentAlreadyEnabled.Code $RM_Extension_Status.AgentAlreadyEnabled.Message -operationName $RM_Extension_Status.AgentAlreadyEnabled.operationName
             Set-HandlerStatus $RM_Extension_Status.Enabled.Code $RM_Extension_Status.Enabled.Message -Status success
             Exit-WithCode 0
             return

--- a/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
+++ b/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
@@ -216,6 +216,11 @@ $global:RM_Extension_Status = @{
         Message = 'Rebooted Pipelines Agent'
         operationName = 'Rebooted Pipelines Agent'
     }
+    PipelinesAgentAlreadyConfigured = @{
+        Code = 79
+        Message = 'Pipelines Agent configuration already exists. Skipping configuration.'
+        operationName = 'Skip Pipeline Agent Configuration'
+    }
 
     #
     # Warnings

--- a/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
+++ b/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
@@ -219,7 +219,7 @@ $global:RM_Extension_Status = @{
     PipelinesAgentAlreadyConfigured = @{
         Code = 79
         Message = 'Pipelines Agent configuration already exists. Skipping configuration.'
-        operationName = 'Skip Pipeline Agent Configuration'
+        operationName = 'Skip Pipelines Agent Configuration'
     }
 
     #

--- a/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
+++ b/ExtensionHandler/Windows/src/bin/RMExtensionStatus.psm1
@@ -216,10 +216,10 @@ $global:RM_Extension_Status = @{
         Message = 'Rebooted Pipelines Agent'
         operationName = 'Rebooted Pipelines Agent'
     }
-    PipelinesAgentAlreadyConfigured = @{
+    AgentAlreadyEnabled = @{
         Code = 79
-        Message = 'Pipelines Agent configuration already exists. Skipping configuration.'
-        operationName = 'Skip Pipelines Agent Configuration'
+        Message = 'Agent Already Enabled Skipping'
+        operationName = 'Agent Already Enabled Skipping'
     }
 
     #


### PR DESCRIPTION
Skip Enable if pipeline agent was already configured successfully before to fix Bug 1995677.
- save sequence number after successfully enabling the pipeline agent, for comparison in next run
- if sequence number is different, check for ".agent" instead of ".autologon" file. .autologon only exists for agents in interactive mode