### PR TITLE
Add elastic pool script log to Linux extension status

### DIFF
--- a/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.23.0.0</Version>
+    <Version>1.23.0.1</Version>
     <Label>Team Services Agent For Linux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for linux machine group machines</Description>

--- a/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
     <ProviderNameSpace>Test.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.150.0.0</Version>
+    <Version>1.151.0.0</Version>
     <Label>TeamServicesAgentLinux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>VSTS agent for machine groups</Description>

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -659,14 +659,16 @@ def enable_pipelines_agent(config):
     handler_utility.log(output.decode("utf-8"))
     handler_utility.log(error.decode("utf-8"))
     if enableProcess.returncode != 0:
-      raise Exception("Pipeline script execution failed with exit code {0}".format(enableProcess.returncode))
+      raise Exception("Pipeline script execution failed with exit code {0}.\n{1}".format(enableProcess.returncode, output.decode('ascii')))
 
   except Exception as e:
     handler_utility.log(str(e))
     set_error_status_and_error_exit(e, RMExtensionStatus.rm_extension_status['EnablePipelinesAgentError']['operationName'], str(e))
     return
 
-  handler_utility.add_handler_sub_status(Util.HandlerSubStatus('EnablePipelinesAgentSuccess'))
+  enable_pipeline_success_substatus = Util.HandlerSubStatus('EnablePipelinesAgentSuccess')
+  enable_pipeline_success_substatus.sub_status_message = output
+  handler_utility.add_handler_sub_status(enable_pipeline_success_substatus)
   handler_utility.set_handler_status(Util.HandlerStatus('Enabled', 'success'))
   handler_utility.log('Pipelines Agent is enabled.')
 

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -574,8 +574,16 @@ def enable_pipelines_agent(config):
     # verify we have the enable script parameters here.
     handler_utility.verify_input_not_null('enableScriptParameters', config["EnableScriptParameters"])
 
-    handler_utility.add_handler_sub_status(Util.HandlerSubStatus('DownloadPipelinesAgent'))
     agentFolder = config["AgentFolder"]
+
+    # verify it wasn't already enabled
+    if (os.path.exists(os.path.join(agentFolder, '.agent'))):
+      handler_utility.log('Agent already enabled. Skipping.')
+      handler_utility.add_handler_sub_status('AgentAlreadyEnabled')
+      handler_utility.set_handler_status(Util.HandlerStatus('Enabled', 'success'))
+      return
+
+    handler_utility.add_handler_sub_status(Util.HandlerSubStatus('DownloadPipelinesAgent'))
     handler_utility.log(agentFolder)
 
     if(not os.path.isdir(agentFolder)):

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -579,7 +579,7 @@ def enable_pipelines_agent(config):
     # verify it wasn't already enabled
     if (os.path.exists(os.path.join(agentFolder, '.agent'))):
       handler_utility.log('Agent already enabled. Skipping.')
-      handler_utility.add_handler_sub_status('AgentAlreadyEnabled')
+      handler_utility.add_handler_sub_status(Util.HandlerSubStatus('AgentAlreadyEnabled'))
       handler_utility.set_handler_status(Util.HandlerStatus('Enabled', 'success'))
       return
 
@@ -667,7 +667,7 @@ def enable_pipelines_agent(config):
     return
 
   enable_pipeline_success_substatus = Util.HandlerSubStatus('EnablePipelinesAgentSuccess')
-  enable_pipeline_success_substatus.sub_status_message = output
+  enable_pipeline_success_substatus.sub_status_message = output.decode('ascii')
   handler_utility.add_handler_sub_status(enable_pipeline_success_substatus)
   handler_utility.set_handler_status(Util.HandlerStatus('Enabled', 'success'))
   handler_utility.log('Pipelines Agent is enabled.')

--- a/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
@@ -196,6 +196,11 @@ rm_extension_status = {
     'Message': 'Enable Pipelines Agent Success',
     'operationName': 'Enable Pipelines Agent Success'
   },
+  'AgentAlreadyEnabled': {
+    'Code': 77,
+    'Message': 'Agent already enabled. Skipping.',
+    'operationName': 'Agent already enabled. Skipping.'
+  },
 
   #
   # Warnings

--- a/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
@@ -198,8 +198,8 @@ rm_extension_status = {
   },
   'AgentAlreadyEnabled': {
     'Code': 77,
-    'Message': 'Agent already enabled. Skipping.',
-    'operationName': 'Agent already enabled. Skipping.'
+    'Message': 'Agent Already Enabled Skipping',
+    'operationName': 'Agent Already Enabled Skipping'
   },
 
   #


### PR DESCRIPTION
Add elastic pool script log to Linux extension substatus to simplify investigations. Also added check of .agent file existence to shorten status files (like #209 for Windows).