### PR TITLE
Fail Linux Extension on .Net6 UnSupported OS

### DIFF
--- a/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.23.0.1</Version>
+    <Version>1.24.0.0</Version>
     <Label>Team Services Agent For Linux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for linux machine group machines</Description>

--- a/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
     <ProviderNameSpace>Test.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.151.0.0</Version>
+    <Version>1.152.0.0</Version>
     <Label>TeamServicesAgentLinux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>VSTS agent for machine groups</Description>

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -139,9 +139,18 @@ def validate_os():
     message = 'The current CPU architecture is not supported. Deployment agent requires x64 architecture.'
     raise RMExtensionStatus.new_handler_terminating_error(code, message)
 
+def os_compatible_with_dotnet6():
+  is_os_compatible = handler_utility.does_system_persists_in_net6_whitelist()
+
+  if(is_os_compatible != True):
+    code = RMExtensionStatus.rm_extension_status['Net6UnSupportedOS']
+    message = 'The current OS version will not be supported by the .NET 6 based v3 agent. See https://aka.ms/azdo-pipeline-agent-version'
+    raise RMExtensionStatus.new_handler_terminating_error(code, message)
+
 def pre_validation_checks():
   try:
     validate_os()
+    os_compatible_with_dotnet6()
     check_python_version()
     check_systemd_exists()
   except Exception as e:

--- a/ExtensionHandler/Linux/src/AzureRM_python2.py
+++ b/ExtensionHandler/Linux/src/AzureRM_python2.py
@@ -137,9 +137,18 @@ def validate_os():
     message = 'The current CPU architecture is not supported. Deployment agent requires x64 architecture.'
     raise RMExtensionStatus.new_handler_terminating_error(code, message)
 
+def os_compatible_with_dotnet6():
+  is_os_compatible = handler_utility.does_system_persists_in_net6_whitelist()
+
+  if(is_os_compatible != True):
+    code = RMExtensionStatus.rm_extension_status['Net6UnSupportedOS']
+    message = 'The current OS version will not be supported by the .NET 6 based v3 agent. See https://aka.ms/azdo-pipeline-agent-version'
+    raise RMExtensionStatus.new_handler_terminating_error(code, message)
+
 def pre_validation_checks():
   try:
     validate_os()
+    os_compatible_with_dotnet6()
     check_python_version()
     check_systemd_exists()
   except Exception as e:

--- a/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
@@ -54,6 +54,7 @@ Example Status Report:
 
 import os
 import os.path
+import re
 import sys
 import imp
 import base64
@@ -508,6 +509,38 @@ class HandlerUtility:
         value = platform.uname()[4]
         output = {'IsX64':value=='x86_64'}
         return output
+
+    def does_system_persists_in_net6_whitelist(self):
+        systemid = None
+        systemversion = None
+
+        if(os.path.exists("/etc/os-release")):
+            with open("/etc/os-release") as os_file:
+                for line in os_file:
+                    linuxIdRegexMatch = re.search("^ID\\s*=\\s*\"?(?P<id>[0-9a-z._-]+)\"?", line)
+                    linuxVersionIdRegexMatch = re.search("^VERSION_ID\\s*=\\s*\"?(?P<vid>[0-9a-z._-]+)\"?",line)
+
+                    if linuxIdRegexMatch:
+                        systemid = linuxIdRegexMatch.group("id")
+
+                    if linuxVersionIdRegexMatch:
+                        systemversion = linuxVersionIdRegexMatch.group("vid")
+
+        net6_supported_os = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+
+        for supported_os in net6_supported_os:
+            if supported_os["id"] == systemid:
+                for version in supported_os["versions"]:
+                    if version["name"] == systemversion:
+                        return True
+                    elif version["name"][-1] == '+':
+                        sysVersion = float(systemversion)
+                        supVersion = float(version["name"][:-1])
+
+                        if sysVersion >= supVersion :
+                            return True
+
+        return False
 
     #def new_handler_terminating_error():
 

--- a/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
@@ -219,6 +219,8 @@ rm_extension_status = {
   'MissingDependency': 52,
   # InputConfigurationError: The extension failed due to missing or wrong configuration parameters
   'InputConfigurationError': 53,
+  # Net6UnSupportedOS: The current OS version is not supported by the .NET 6 based v3 agent
+  'Net6UnSupportedOS' : 54,
 
   'AgentUnConfigureFailWarning' : 'There are some warnings in uninstalling the already existing agent. Check \"Detailed Status\" for more details.'
 }

--- a/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
@@ -54,6 +54,7 @@ Example Status Report:
 
 import os
 import os.path
+import re
 import sys
 import imp
 import base64
@@ -508,6 +509,38 @@ class HandlerUtility:
         value = platform.uname()[4]
         output = {'IsX64':value=='x86_64'}
         return output
+
+    def does_system_persists_in_net6_whitelist(self):
+        systemid = None
+        systemversion = None
+
+        if(os.path.exists("/etc/os-release")):
+            with open("/etc/os-release") as os_file:
+                for line in os_file:
+                    linuxIdRegexMatch = re.search("^ID\\s*=\\s*\"?(?P<id>[0-9a-z._-]+)\"?", line)
+                    linuxVersionIdRegexMatch = re.search("^VERSION_ID\\s*=\\s*\"?(?P<vid>[0-9a-z._-]+)\"?",line)
+
+                    if linuxIdRegexMatch:
+                        systemid = linuxIdRegexMatch.group("id")
+
+                    if linuxVersionIdRegexMatch:
+                        systemversion = linuxVersionIdRegexMatch.group("vid")
+
+        net6_supported_os = json.loads(urllib2.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+
+        for supported_os in net6_supported_os:
+            if supported_os["id"] == systemid:
+                for version in supported_os["versions"]:
+                    if version["name"] == systemversion:
+                        return True
+                    elif version["name"][-1] == '+':
+                        sysVersion = float(systemversion)
+                        supVersion = float(version["name"][:-1])
+
+                        if sysVersion >= supVersion :
+                            return True
+
+        return False
 
     #def new_handler_terminating_error():
 

--- a/ExtensionHandler/Linux/src/Utils_python2/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/RMExtensionStatus.py
@@ -214,6 +214,8 @@ rm_extension_status = {
   'MissingDependency': 52,
   # InputConfigurationError: The extension failed due to missing or wrong configuration parameters
   'InputConfigurationError': 53,
+  # Net6UnSupportedOS: The current OS version is not supported by the .NET 6 based v3 agent
+  'Net6UnSupportedOS' : 54,
 
   'AgentUnConfigureFailWarning' : 'There are some warnings in uninstalling the already existing agent. Check \"Detailed Status\" for more details.'
 }


### PR DESCRIPTION
Fail to provision agent if the OS is not supported by .NET6 based v3 agent.

https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2033449/