### PR TITLE
Fail Linux Extension on .Net6 UnSupported OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ e2eTests/publicConfig.json
 e2eTests/template.json
 e2eTests/TestEnvironment.json
 .vscode/launch.json
+.venv

--- a/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">   
     <ProviderNameSpace>Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.23.0.1</Version>
+    <Version>1.24.0.0</Version>
     <Label>Team Services Agent For Linux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>Team Services agent for linux machine group machines</Description>

--- a/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
     <ProviderNameSpace>Test.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.151.0.0</Version>
+    <Version>1.152.0.0</Version>
     <Label>TeamServicesAgentLinux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>VSTS agent for machine groups</Description>

--- a/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
+++ b/ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml
@@ -2,7 +2,7 @@
   <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
     <ProviderNameSpace>Test.Microsoft.VisualStudio.Services</ProviderNameSpace>
     <Type>TeamServicesAgentLinux</Type>
-    <Version>1.152.0.0</Version>
+    <Version>1.153.0.0</Version>
     <Label>TeamServicesAgentLinux</Label>
     <HostingResources>VmRole</HostingResources>
     <Description>VSTS agent for machine groups</Description>

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -29,6 +29,7 @@ MAX_RETRIES = 3
 configured_agent_exists = False
 agent_configuration_required = True
 root_dir = ''
+handler_utility = None
 
 def get_last_sequence_number_file_path():
   global root_dir

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -15,6 +15,7 @@ import DownloadDeploymentAgent
 import ConfigureDeploymentAgent
 import json
 import time
+import logging
 import shutil
 from Utils.WAAgentUtil import waagent
 from Utils.GlobalSettings import proxy_config
@@ -24,12 +25,32 @@ from urllib.parse import quote
 import urllib.request, urllib.parse, urllib.error
 import shlex
 
+from aria import LogManager, EventProperties, PiiKind, LogConfiguration, LogManagerConfiguration
+
 MAX_RETRIES = 3
 
 configured_agent_exists = False
 agent_configuration_required = True
 root_dir = ''
 handler_utility = None
+event_logger = None
+
+class EventLogger:
+  tenant_token = "5413d41fa2bc4f969c283b8b79f23488-c3090565-2202-41ce-bb2c-76f26d7575ee-7318"
+
+  def __init__(self):
+    log_config = LogConfiguration(log_level = logging.DEBUG)
+    configuration = LogManagerConfiguration(log_configuration = log_config)
+
+    LogManager.initialize(self.tenant_token, configuration)
+    self._event_logger = LogManager.get_logger("", self.tenant_token)
+
+  def log_new_event(self, event_type, message):
+    event_properties = EventProperties(event_type)
+    event_properties.set_property("SystemID", handler_utility._systemid)
+    event_properties.set_property("SystemVersion", handler_utility._systemversion)
+    event_properties.set_property("Message", message)
+    self._event_logger.log_event(event_properties)
 
 def get_last_sequence_number_file_path():
   global root_dir
@@ -107,6 +128,11 @@ def set_error_status_and_error_exit(e, operation_name, code = -1):
   if(len(error_message) > Constants.ERROR_MESSAGE_LENGTH):
     error_message = error_message[:Constants.ERROR_MESSAGE_LENGTH]
   handler_utility.error('Error occured during {0}. {1}'.format(operation_name, error_message))
+  try:
+    event_logger.log_new_event("extension_failed", 'Error occured during {0}. {1}'.format(operation_name, error_message))
+  except Exception:
+    pass
+  LogManager.flush(timeout=0)
   exit_with_code(code)
 
 def check_python_version():
@@ -197,6 +223,7 @@ def compare_sequence_number():
     if((sequence_number == last_sequence_number) and not(test_extension_disabled_markup())):
       handler_utility.log(RMExtensionStatus.rm_extension_status['SkippedInstallation']['Message'])
       handler_utility.log('Skipping enable since seq numbers match. Seq number: {0}.'.format(sequence_number))
+      LogManager.flush(timeout=0)
       exit_with_code(0)
 
   except Exception as e:
@@ -769,6 +796,8 @@ def main():
   if(len(sys.argv) == 2):
     global handler_utility
     handler_utility = Util.HandlerUtility(waagent.Log, waagent.Error)
+    global event_logger
+    event_logger = EventLogger()
     operation = sys.argv[1]
     #Settings are read from file in do_parse_context, and protected settings are also removed from the file in this function
     handler_utility.do_parse_context(operation)
@@ -790,6 +819,11 @@ def main():
       elif(input_operation == Constants.UPDATE):
         update()
 
+      try:
+        event_logger.log_new_event("extension_succeeded", "Extension successfully installed")
+      except Exception:
+        pass
+      LogManager.flush(timeout=0)
       exit_with_code(0)
     except Exception as e:
       set_error_status_and_error_exit(e, 'main', 9)

--- a/ExtensionHandler/Linux/src/AzureRM.py
+++ b/ExtensionHandler/Linux/src/AzureRM.py
@@ -139,9 +139,18 @@ def validate_os():
     message = 'The current CPU architecture is not supported. Deployment agent requires x64 architecture.'
     raise RMExtensionStatus.new_handler_terminating_error(code, message)
 
+def os_compatible_with_dotnet6():
+  is_os_compatible = handler_utility.does_system_persists_in_net6_whitelist()
+
+  if(is_os_compatible != True):
+    code = RMExtensionStatus.rm_extension_status['Net6UnSupportedOS']
+    message = 'The current OS version will not be supported by the .NET 6 based v3 agent. See https://aka.ms/azdo-pipeline-agent-version'
+    raise RMExtensionStatus.new_handler_terminating_error(code, message)
+
 def pre_validation_checks():
   try:
     validate_os()
+    os_compatible_with_dotnet6()
     check_python_version()
     check_systemd_exists()
   except Exception as e:

--- a/ExtensionHandler/Linux/src/AzureRM_python2.py
+++ b/ExtensionHandler/Linux/src/AzureRM_python2.py
@@ -137,9 +137,18 @@ def validate_os():
     message = 'The current CPU architecture is not supported. Deployment agent requires x64 architecture.'
     raise RMExtensionStatus.new_handler_terminating_error(code, message)
 
+def os_compatible_with_dotnet6():
+  is_os_compatible = handler_utility.does_system_persists_in_net6_whitelist()
+
+  if(is_os_compatible != True):
+    code = RMExtensionStatus.rm_extension_status['Net6UnSupportedOS']
+    message = 'The current OS version will not be supported by the .NET 6 based v3 agent. See https://aka.ms/azdo-pipeline-agent-version'
+    raise RMExtensionStatus.new_handler_terminating_error(code, message)
+
 def pre_validation_checks():
   try:
     validate_os()
+    os_compatible_with_dotnet6()
     check_python_version()
     check_systemd_exists()
   except Exception as e:

--- a/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
@@ -530,7 +530,8 @@ class HandlerUtility:
         try:
             net6_supported_os = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
         except:
-            net6_supported_os =json.loads(open("../net6.json").read())
+            with open("../net6.json") as net6_file:
+                net6_supported_os = json.loads(net6_file.read())
 
         for supported_os in net6_supported_os:
             if supported_os["id"] == systemid:

--- a/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
@@ -510,7 +510,8 @@ class HandlerUtility:
         output = {'IsX64':value=='x86_64'}
         return output
 
-    def does_system_persists_in_net6_whitelist(self):
+    @staticmethod
+    def does_system_persists_in_net6_whitelist():
         systemid = None
         systemversion = None
 

--- a/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils/HandlerUtil.py
@@ -527,7 +527,10 @@ class HandlerUtility:
                     if linuxVersionIdRegexMatch:
                         systemversion = linuxVersionIdRegexMatch.group("vid")
 
-        net6_supported_os = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        try:
+            net6_supported_os = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        except:
+            net6_supported_os =json.loads(open("../net6.json").read())
 
         for supported_os in net6_supported_os:
             if supported_os["id"] == systemid:

--- a/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils/RMExtensionStatus.py
@@ -219,6 +219,8 @@ rm_extension_status = {
   'MissingDependency': 52,
   # InputConfigurationError: The extension failed due to missing or wrong configuration parameters
   'InputConfigurationError': 53,
+  # Net6UnSupportedOS: The current OS version is not supported by the .NET 6 based v3 agent
+  'Net6UnSupportedOS' : 54,
 
   'AgentUnConfigureFailWarning' : 'There are some warnings in uninstalling the already existing agent. Check \"Detailed Status\" for more details.'
 }

--- a/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
@@ -530,7 +530,8 @@ class HandlerUtility:
         try:
             net6_supported_os = json.loads(urllib2.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
         except:
-            net6_supported_os =json.loads(open("../net6.json").read())
+            with open("../net6.json") as net6_file:
+                net6_supported_os = json.loads(net6_file.read())
 
         for supported_os in net6_supported_os:
             if supported_os["id"] == systemid:

--- a/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
@@ -527,7 +527,10 @@ class HandlerUtility:
                     if linuxVersionIdRegexMatch:
                         systemversion = linuxVersionIdRegexMatch.group("vid")
 
-        net6_supported_os = json.loads(urllib2.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        try:
+            net6_supported_os = json.loads(urllib2.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        except:
+            net6_supported_os =json.loads(open("../net6.json").read())
 
         for supported_os in net6_supported_os:
             if supported_os["id"] == systemid:

--- a/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
@@ -510,7 +510,8 @@ class HandlerUtility:
         output = {'IsX64':value=='x86_64'}
         return output
 
-    def does_system_persists_in_net6_whitelist(self):
+    @staticmethod
+    def does_system_persists_in_net6_whitelist():
         systemid = None
         systemversion = None
 

--- a/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/HandlerUtil.py
@@ -54,6 +54,7 @@ Example Status Report:
 
 import os
 import os.path
+import re
 import sys
 import imp
 import base64
@@ -509,6 +510,37 @@ class HandlerUtility:
         output = {'IsX64':value=='x86_64'}
         return output
 
+    def does_system_persists_in_net6_whitelist(self):
+        systemid = None
+        systemversion = None
+
+        if(os.path.exists("/etc/os-release")):
+            with open("/etc/os-release") as os_file:
+                for line in os_file:
+                    linuxIdRegexMatch = re.search("^ID\\s*=\\s*\"?(?P<id>[0-9a-z._-]+)\"?", line)
+                    linuxVersionIdRegexMatch = re.search("^VERSION_ID\\s*=\\s*\"?(?P<vid>[0-9a-z._-]+)\"?",line)
+
+                    if linuxIdRegexMatch:
+                        systemid = linuxIdRegexMatch.group("id")
+
+                    if linuxVersionIdRegexMatch:
+                        systemversion = linuxVersionIdRegexMatch.group("vid")
+
+        net6_supported_os = json.loads(urllib2.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+
+        for supported_os in net6_supported_os:
+            if supported_os["id"] == systemid:
+                for version in supported_os["versions"]:
+                    if version["name"] == systemversion:
+                        return True
+                    elif version["name"][-1] == '+':
+                        sysVersion = float(systemversion)
+                        supVersion = float(version["name"][:-1])
+
+                        if sysVersion >= supVersion :
+                            return True
+
+        return False
     #def new_handler_terminating_error():
 
     def verify_input_not_null(self, input_key, input_value = None):

--- a/ExtensionHandler/Linux/src/Utils_python2/RMExtensionStatus.py
+++ b/ExtensionHandler/Linux/src/Utils_python2/RMExtensionStatus.py
@@ -214,6 +214,8 @@ rm_extension_status = {
   'MissingDependency': 52,
   # InputConfigurationError: The extension failed due to missing or wrong configuration parameters
   'InputConfigurationError': 53,
+  # Net6UnSupportedOS: The current OS version is not supported by the .NET 6 based v3 agent
+  'Net6UnSupportedOS' : 54,
 
   'AgentUnConfigureFailWarning' : 'There are some warnings in uninstalling the already existing agent. Check \"Detailed Status\" for more details.'
 }

--- a/ExtensionHandler/Linux/src/aria/__init__.py
+++ b/ExtensionHandler/Linux/src/aria/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+__all__ = ['LogManager', 'PiiKind', 'EventProperties', 'LogManagerConfiguration', 'LogConfiguration', 'Logger']
+
+__author__ = 'Ionescu Marius Robert'
+
+__version__ = '1.3.9.0'
+
+from aria.log_manager import LogManager
+from aria.event_properties import EventProperties
+from aria.pii import PiiKind
+from aria.configuration import LogManagerConfiguration
+from aria.log_config import LogConfiguration
+from aria.logger import Logger

--- a/ExtensionHandler/Linux/src/aria/aria_log.py
+++ b/ExtensionHandler/Linux/src/aria/aria_log.py
@@ -1,0 +1,6 @@
+from logging import getLogger, handlers
+from threading import RLock
+
+class AriaLog(object):
+    aria_log = getLogger("aria")
+    aria_log_lock = RLock()

--- a/ExtensionHandler/Linux/src/aria/batch_package.py
+++ b/ExtensionHandler/Linux/src/aria/batch_package.py
@@ -1,0 +1,152 @@
+from __future__ import absolute_import
+from threading import RLock
+import aria.log_manager
+from .batching_package import BatchingPackage
+from .log_config import AriaLog
+from sys import exc_info
+from .subscribe import SubscribeStatus
+from .stats_manager import StatsConstants
+
+class BatchPackage(object):
+    queue = []          
+    queue_to_send = []  
+    queue_to_send_lock = RLock()
+    queue_lock = RLock()
+    
+    @staticmethod
+    def add_records(record_list):
+        ''' a list of BatchingRecords '''
+
+        AriaLog.aria_log.debug("Put records into packages")
+        with BatchPackage.queue_lock:
+            for batching_record in record_list:
+                if batching_record.bond_failed == True:
+                    AriaLog.aria_log.debug("Bond failed, event dropped, event_sequence_id=" + str(batching_record.sequence_id))
+                    aria.log_manager.LogManagerImpl.stats_manager.records_bond_failed(batching_record.tenant, 1)
+                    
+                    if StatsConstants.stats_tenant_token != batching_record.tenant:
+                        aria.log_manager.LogManagerImpl.decrement_events_in_memory(1)
+                        
+                    aria.log_manager.LogManagerImpl.subscribers.update(batching_record.tenant, [batching_record.sequence_id], SubscribeStatus.BOND_FAILED)
+                    aria.log_manager.LogManagerImpl.stats_manager.events_dropped(batching_record.tenant, 1)
+                else:
+                    try:
+                        if aria.log_manager.LogManagerImpl.configuration.MAX_SIZE_ALLOWED < batching_record.size:
+                            AriaLog.aria_log.debug("Record reached the maximum size allowed")
+                            AriaLog.aria_log.debug("Max size=" + str(aria.log_manager.LogManagerImpl.configuration.MAX_SIZE_ALLOWED) + ", record_size=" + str(batching_record.size))
+                            
+                            if StatsConstants.stats_tenant_token != batching_record.tenant:
+                                aria.log_manager.LogManagerImpl.decrement_events_in_memory(1)
+                            
+                            aria.log_manager.LogManagerImpl.stats_manager.events_dropped(batching_record.tenant, 1)
+                            aria.log_manager.LogManagerImpl.stats_manager.records_dropped_status(batching_record.tenant, 1, "event_to_big")
+                            aria.log_manager.LogManagerImpl.subscribers.update(batching_record.tenant, [batching_record.sequence_id], SubscribeStatus.EVENT_TO_BIG)
+                            continue
+                        
+                        found_tenant = False
+                        for index in range(len(BatchPackage.queue)):
+                            if batching_record.tenant == BatchPackage.queue[index].tenant:
+                                if BatchPackage.queue[index].size + batching_record.size < aria.log_manager.LogManagerImpl.configuration.MAX_SIZE_ALLOWED:
+                                    found_tenant = True
+                                    BatchPackage.queue[index].records += 1
+                                    BatchPackage.queue[index].serialized += batching_record.record
+                                    BatchPackage.queue[index].size += batching_record.size
+                                    BatchPackage.queue[index].records_list.append(batching_record.sequence_id)
+                                    break
+                                else:
+                                    BatchPackage.queue[index].max_size_reached = True
+                                    
+                        if found_tenant == False:
+                            AriaLog.aria_log.debug("New package was created")
+                            package = BatchingPackage(batching_record.tenant, batching_record.size)
+                            package.serialized += batching_record.record
+                            package.records = 1
+                            package.records_list.append(batching_record.sequence_id)
+                            BatchPackage.queue.append(package)
+                    except:
+                        if aria.log_manager.LogManagerImpl.stats_manager != None:
+                            if StatsConstants.stats_tenant_token != batching_record.tenant:
+                                aria.log_manager.LogManagerImpl.decrement_events_in_memory(1)
+                            
+                            aria.log_manager.LogManagerImpl.subscribers.update(batching_record.tenant, [batching_record.sequence_id], SubscribeStatus.PATCHING_FAILED)
+                            aria.log_manager.LogManagerImpl.stats_manager.records_dropped_status(batching_record.tenant, 1, "packaging_failed")
+                        AriaLog.aria_log.warning("BatchPackage failed " + str(exc_info()[0]))
+                # Feed the sender
+            BatchPackage.feed_sender()
+            
+    @staticmethod
+    def feed_sender():
+        from .batcher import Batcher
+        
+        #Try to send the packages with 3MB
+        if len(Batcher.out_queue) <  aria.log_manager.LogManagerImpl.configuration.TCP_CONNECTIONS:
+            with BatchPackage.queue_lock:
+                packages_index_to_remove = []
+                for index in range(len(BatchPackage.queue)):
+                    if BatchPackage.queue[index].max_size_reached == True:
+                        AriaLog.aria_log.debug("Package has reached maximum size, moved into the sender queue")
+                        packages_index_to_remove.append(index)
+                        BatchPackage.queue[index].open_batching()
+                        BatchPackage.queue[index].close_batching()
+                        with BatchPackage.queue_to_send_lock:
+                            BatchPackage.queue_to_send.append(BatchPackage.queue[index])
+            
+                if len(packages_index_to_remove) > 0:
+                    reverse_list = reversed(packages_index_to_remove)
+                    for index in reverse_list:
+                        del BatchPackage.queue[index]
+        
+            # Try to fill out the queue to not starve the open connection
+            with BatchPackage.queue_lock:
+                packages_index_to_remove = []
+                for index in range(len(BatchPackage.queue)):
+                    with Batcher.out_queue_lock:
+                        if len(Batcher.out_queue) < aria.log_manager.LogManagerImpl.configuration.TCP_CONNECTIONS or Batcher.is_flushed:
+                            AriaLog.aria_log.debug("Package put into the sender queue")
+                            BatchPackage.queue[index].open_batching()
+                            BatchPackage.queue[index].close_batching()
+                            Batcher.out_queue.append(BatchPackage.queue[index])
+                            packages_index_to_remove.append(index)
+                        
+                if len(packages_index_to_remove) > 0:
+                    reverse_list = reversed(packages_index_to_remove)
+                    for index in reverse_list:
+                        del BatchPackage.queue[index]
+    
+    @staticmethod
+    def flush_packages():
+        from .batcher import Batcher
+        with BatchPackage.queue_lock:
+            for index in range(len(BatchPackage.queue)):
+                with Batcher.out_queue_lock:
+                    AriaLog.aria_log.debug("Flush_packages Package put into the sender queue")
+                    BatchPackage.queue[index].open_batching()
+                    BatchPackage.queue[index].close_batching()
+                    Batcher.out_queue.append(BatchPackage.queue[index])
+        
+        with BatchPackage.queue_to_send_lock:
+            with Batcher.out_queue_lock:
+                for package in BatchPackage.queue_to_send:
+                    AriaLog.aria_log.debug("Flush_packages Package put into the sender queue")
+                    Batcher.out_queue.append(package)
+
+    @staticmethod
+    def remove_package_from_ready_queue():
+        with BatchPackage.queue_to_send_lock:
+            if len(BatchPackage.queue_to_send) > 0:
+                package = BatchPackage.queue_to_send[0]
+                del BatchPackage.queue_to_send[0]
+                AriaLog.aria_log.debug("Remove 3 MB package")
+                return package
+            return None
+    
+    @staticmethod
+    def remove_package_from_queue():
+        with BatchPackage.queue_lock:
+            if len(BatchPackage.queue) > 0:
+                package = BatchPackage.queue[0]
+                del BatchPackage.queue[0]
+                AriaLog.aria_log.debug("Remove a regular package")
+                return package
+            return None
+            

--- a/ExtensionHandler/Linux/src/aria/batcher.py
+++ b/ExtensionHandler/Linux/src/aria/batcher.py
@@ -1,0 +1,331 @@
+from __future__ import absolute_import
+from time import sleep
+from threading import Thread
+from threading import RLock
+import aria.log_manager
+#from . import log_manager
+from . import batch_package
+import multiprocessing
+from .bond import SerializeEvents
+from .log_config import AriaLog
+from sys import exc_info
+from .subscribe import SubscribeStatus
+from . import stats_manager
+from .stats_manager import StatsConstants
+
+class Batcher(object):
+    out_queue = []
+    in_queue = []
+    out_queue_lock = RLock()
+    in_queue_lock = RLock()
+    batcher_thread_running = False
+    sender_thread_running = False
+    sender_thread_lazy_running = False
+    batcher_lazy_thread_running= False
+    bathcer_thread_list = []
+    is_flushed = False
+    
+    @staticmethod
+    def clean_up():
+        AriaLog.aria_log.info("Clean up")
+        Batcher.out_queue = []
+        Batcher.in_queue = []
+        Batcher.out_queue_lock = RLock()
+        Batcher.in_queue_lock = RLock()
+        Batcher.batcher_thread_running = False
+        Batcher.sender_thread_running = False
+        Batcher.sender_thread_lazy_running = False
+        Batcher.batcher_lazy_thread_running= False
+        Batcher.is_flushed = False
+    
+    @staticmethod
+    def stop_and_clean_up():
+        AriaLog.aria_log.info("Stop")
+        try:
+            Batcher.clean_up()
+            for i in Batcher.bathcer_thread_list:
+                if i != None:
+                    i.join(1)
+            Batcher.bathcer_thread_list = None
+            return True
+        except:
+            AriaLog.aria_log.warning("Stop failed " + str(exc_info()[0]))
+            return False
+    
+    @staticmethod
+    def flush():
+        AriaLog.aria_log.info("Flush was called")
+        Batcher.is_flushed = True
+        Batcher.send_all_remaining_events()
+        # Turn all threads off
+        Batcher.batcher_thread_running = False
+        Batcher.batcher_lazy_thread_running = False
+        Batcher.sender_thread_running = False
+        Batcher.sender_thread_lazy_running = False
+
+        # wait for all threads to be done
+        for i in Batcher.bathcer_thread_list:
+            if i != None:
+                i.join(0.1)
+
+        Batcher.bathcer_thread_list = None
+
+        Batcher.sender_thread.join(0.1)
+        Batcher.sender_thread_lazy.join(0.1)
+        Batcher.sender_thread = None
+        Batcher.sender_thread_lazy = None
+        # Send all remaining events to packages
+        batch_package.BatchPackage.flush_packages()
+        return True
+        
+    @staticmethod
+    def send_all_remaining_events():
+        # SDK doesn't received any more 
+        AriaLog.aria_log.info("SDK was stopped and it's sending all the remaining events")
+        try:
+            records = Batcher.remove_record_from_in_leazy(len(Batcher.in_queue))
+            if records != None:
+                records_size = len(records)
+                AriaLog.aria_log.info("Number of remaining events " + str(records_size))
+                for i in range(0, records_size, 200):
+                    end = i + 200 if i + 200 < records_size else records_size
+                    if aria.log_manager.LogManagerImpl.configuration.PROCESS_NUMBER > 0:
+                        aria.log_manager.LogManagerImpl.pool_process.apply_async(SerializeEvents, args=(records[i:end],), callback = batch_package.BatchPackage.add_records).get()
+                    else:
+                        batch_package.BatchPackage.add_records(SerializeEvents(records[i:end]))
+        except:
+            AriaLog.aria_log.warning("SDK was stopped and it's sending all the remaining events failed " + str(exc_info()[0]))
+            
+    @staticmethod
+    def define_threads():
+        # Make sure we start with a clean state
+        Batcher.sender_thread = None
+        Batcher.sender_thread_lazy = None
+
+        AriaLog.aria_log.info("Define batcher threads")
+        try:
+            Batcher.sender_thread = Thread(target = Batcher.__run_sender)
+            Batcher.sender_thread_lazy = Thread(target = Batcher.__run_sender_lazy)
+        except:
+            AriaLog.aria_log.warning("Define batcher threads " + str(exc_info()[0]))
+            
+    @staticmethod
+    def start_sender_lazy_thread():
+        AriaLog.aria_log.info("Start lazy thread")
+        Batcher.sender_thread_lazy_running = True
+        Batcher.sender_thread_lazy.start()
+
+    @staticmethod    
+    def start_batcher_thread():
+        AriaLog.aria_log.info("Start batcher thread")
+        Batcher.batcher_thread_running = True
+        Batcher.batcher_lazy_thread_running = True
+        Batcher.bathcer_thread_list = []
+        batcher_th = None
+
+        if aria.log_manager.LogManagerImpl.configuration.PROCESS_NUMBER > 0:
+            AriaLog.aria_log.debug("Bond serialize process number=" + str(aria.log_manager.LogManagerImpl.configuration.PROCESS_NUMBER))
+            for i in range(aria.log_manager.LogManagerImpl.configuration.PROCESS_NUMBER):
+                th = Thread(target = Batcher.__run_batcher)
+                th.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON
+                th.start()
+                Batcher.bathcer_thread_list.append(th)
+                AriaLog.aria_log.debug("Batcher started number" + str(i))
+                
+            batcher_th = Thread(target = Batcher.__run_batcher_lazy)
+            batcher_th.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON 
+            batcher_th.start()
+            Batcher.bathcer_thread_list.append(batcher_th)
+        else:
+            th = Thread(target=Batcher.__run_batcher_thread)
+            th.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON
+            th.start()
+            Batcher.bathcer_thread_list.append(batcher_th)
+
+            th = Thread(target=Batcher.__run_batcher_lazy_thread)
+            th.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON
+            th.start()
+            Batcher.bathcer_thread_list.append(batcher_th)
+    
+    @staticmethod
+    def start_sender_thread():
+        AriaLog.aria_log.info("Start sender thread")
+        Batcher.sender_thread_running = True
+        Batcher.sender_thread.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON 
+        Batcher.sender_thread.start()
+
+    @staticmethod
+    def __run_batcher_thread():
+        AriaLog.aria_log.info("__run_batcher_thread started")
+        while Batcher.batcher_thread_running == True:
+            records = Batcher.remove_records_from_in(aria.log_manager.LogManagerImpl.configuration.MAX_EVENTS_TO_BATCH)
+            if records != None:
+                AriaLog.aria_log.debug("Processing records" + " Records=" + str(len(records)))
+                batch_package.BatchPackage.add_records(SerializeEvents(records))
+            sleep(aria.log_manager.LogManagerImpl.configuration.BATCHER_TIMER)
+    
+    @staticmethod
+    def __run_batcher():
+        AriaLog.aria_log.info("__run_batcher started")
+        while Batcher.batcher_thread_running == True:
+            records = Batcher.remove_records_from_in(aria.log_manager.LogManagerImpl.configuration.MAX_EVENTS_TO_BATCH)
+            if records != None:
+                AriaLog.aria_log.debug("Processing records async" + " Records=" + str(len(records)))
+                aria.log_manager.LogManagerImpl.pool_process.apply_async(SerializeEvents, args=(records,), callback = batch_package.BatchPackage.add_records).get()
+            sleep(aria.log_manager.LogManagerImpl.configuration.BATCHER_TIMER)
+    
+    @staticmethod
+    def __run_batcher_lazy_thread():
+        AriaLog.aria_log.info("__run_batcher_lazy_thread started")
+        while Batcher.batcher_lazy_thread_running == True:
+            records = Batcher.remove_record_from_in_leazy(aria.log_manager.LogManagerImpl.configuration.MAX_EVENTS_TO_BATCH)
+            if records != None:
+                AriaLog.aria_log.debug("Processing records" + " Records=" + str(len(records)))
+                batch_package.BatchPackage.add_records(SerializeEvents(records))
+            sleep(aria.log_manager.LogManagerImpl.configuration.LAZY_BATCHER_TIMER)
+            
+    @staticmethod
+    def __run_batcher_lazy():
+        AriaLog.aria_log.info("__run_batcher_lazy started")
+        while Batcher.batcher_lazy_thread_running == True:
+            records = Batcher.remove_record_from_in_leazy(aria.log_manager.LogManagerImpl.configuration.MAX_EVENTS_TO_BATCH)
+            if records != None:
+                AriaLog.aria_log.debug("Processing records async" + " Records=" + str(len(records)))
+                aria.log_manager.LogManagerImpl.pool_process.apply_async(SerializeEvents, args=(records,), callback = batch_package.BatchPackage.add_records).get()
+            sleep(aria.log_manager.LogManagerImpl.configuration.LAZY_BATCHER_TIMER)
+    
+    @staticmethod
+    def __run_sender():
+        ''' Only sends 3MB Packages'''
+        while Batcher.sender_thread_running == True:
+            package = batch_package.BatchPackage.remove_package_from_ready_queue()
+            if package != None:
+                with Batcher.out_queue_lock:
+                    Batcher.out_queue.append(package)
+                AriaLog.aria_log.debug("Put a 3MB package in the queue to send")    
+            else:
+                sleep(aria.log_manager.LogManagerImpl.configuration.SENDER_TIMER)
+    
+    @staticmethod
+    def __run_sender_lazy():
+        ''' This adds all the events and send them to be batched per tenant ID'''
+        while Batcher.sender_thread_lazy_running == True:
+            package = batch_package.BatchPackage.remove_package_from_queue()
+            if package != None:
+                package.open_batching()
+                package.close_batching()
+                with Batcher.out_queue_lock:
+                    Batcher.out_queue.append(package)
+                AriaLog.aria_log.debug("Put any package there is in the queue in queue to send")
+            sleep(aria.log_manager.LogManagerImpl.configuration.SENDER_LAZY_TIMER)
+    
+    @staticmethod
+    def add_record(tenant, record):        
+        with Batcher.in_queue_lock:
+            Batcher.in_queue.append(record)
+        if StatsConstants.stats_tenant_token != tenant:
+            aria.log_manager.LogManagerImpl.increment_events_in_memory(1)
+
+    @staticmethod        
+    def remove_record_from_in_leazy(count):    
+        with Batcher.in_queue_lock:
+            if len(Batcher.in_queue) != 0:
+                if count > len(Batcher.in_queue):
+                    count = len(Batcher.in_queue)
+                AriaLog.aria_log.debug("Lazy Removed records from the queue Records=" + str(count))
+                records = Batcher.in_queue[:count]
+                del Batcher.in_queue[:count]
+                return records
+            return None
+        
+    @staticmethod
+    def remove_records_from_in(count):
+        with Batcher.in_queue_lock:
+            if len(Batcher.in_queue) != 0:
+                if count < len(Batcher.in_queue):
+                    AriaLog.aria_log.debug("Removed records from the queue Records=" + str(count))
+                    records = Batcher.in_queue[:count]
+                    del Batcher.in_queue[:count]
+                    return records
+            return None
+    
+    @staticmethod        
+    def remove_package_from_out():
+        with Batcher.out_queue_lock:
+            if len(Batcher.out_queue) > 0:
+                package = Batcher.out_queue[0]
+                del Batcher.out_queue[0]
+                AriaLog.aria_log.debug("Remove package to be send")
+                return package
+            AriaLog.aria_log.debug("Sender thread was starved")
+            return None
+    
+    @staticmethod
+    def drop_events():
+        # lock all objects and try to delete from the outer queue, then from the queue and then from the inner queue
+    
+        records_to_remove = aria.log_manager.LogManagerImpl.configuration.QUEUE_DROPPED_EVENTS
+        AriaLog.aria_log.info("We are dropping events" + str(records_to_remove))
+        records_removed = False
+        
+        #try:
+        while records_to_remove != 0:
+            with  Batcher.in_queue_lock:
+                if len(Batcher.in_queue) >= records_to_remove:
+                    records = Batcher.in_queue[:records_to_remove]
+                    del Batcher.in_queue[:records_to_remove]
+                    
+                    for rec in records:
+                        aria.log_manager.LogManagerImpl.subscribers.update(rec.tenant, [rec.sequence_id], SubscribeStatus.MAX_SIZE_REACHED)
+                        aria.log_manager.LogManagerImpl.stats_manager.events_dropped(rec.tenant, 1)
+                        aria.log_manager.LogManagerImpl.stats_manager.records_dropped_status(rec.tenant, 1, "queue_max_size_reached")
+                    
+                        if StatsConstants.stats_tenant_token != rec.tenant:
+                            aria.log_manager.LogManagerImpl.decrement_events_in_memory(1)
+                        
+                    AriaLog.aria_log.info("Events are being dropped, dropped=" + str(len(records)))
+
+                    # stats, subscribers, logManager, log
+                    records_removed = True
+                    
+            if records_removed == False:
+                with batch_package.BatchPackage.queue_lock:
+                    index_found = -1
+                    for index in range(len(batch_package.BatchPackage.queue)):
+                        if len(batch_package.BatchPackage.queue[index].records_list) >= records_to_remove:
+                            aria.log_manager.LogManagerImpl.subscribers.update(batch_package.BatchPackage.queue[index].tenant, batch_package.BatchPackage.queue[index].records_list, SubscribeStatus.MAX_SIZE_REACHED)
+                            aria.log_manager.LogManagerImpl.stats_manager.events_dropped(batch_package.BatchPackage.queue[index].tenant, batch_package.BatchPackage.queue[index].records)
+                            aria.log_manager.LogManagerImpl.stats_manager.records_dropped_status(batch_package.BatchPackage.queue[index].tenant, batch_package.BatchPackage.queue[index].records, "queue_max_size_reached")
+                            if StatsConstants.stats_tenant_token != batch_package.BatchPackage.queue[index].tenant:
+                                aria.log_manager.LogManagerImpl.decrement_events_in_memory(batch_package.BatchPackage.queue[index].records)
+                            AriaLog.aria_log.info("Events are being dropped, dropped=" + str(batch_package.BatchPackage.queue[index].records))
+                            index_found = index
+                            records_removed = True
+                            break
+                        
+                    if index_found != -1:
+                        del batch_package.BatchPackage.queue[index_found]
+            if records_removed == False:
+                with Batcher.out_queue_lock:
+                    index_found = -1
+                    for index in range(len(Batcher.out_queue)):
+                        if len(Batcher.out_queue[index].records_list) >= records_to_remove:
+                            aria.log_manager.LogManagerImpl.subscribers.update(Batcher.out_queue[index].tenant, Batcher.out_queue[index].records_list, SubscribeStatus.MAX_SIZE_REACHED)
+                            aria.log_manager.LogManagerImpl.stats_manager.events_dropped(Batcher.out_queue[index].tenant, Batcher.out_queue[index].records)
+                            aria.log_manager.LogManagerImpl.stats_manager.records_dropped_status(Batcher.out_queue[index].tenant, Batcher.out_queue[index].records, "queue_max_size_reached")
+                            if StatsConstants.stats_tenant_token != Batcher.out_queue[index].tenant:
+                                aria.log_manager.LogManagerImpl.decrement_events_in_memory(Batcher.out_queue[index].records)
+                            AriaLog.aria_log.info("Events are being dropped, dropped=" + str(Batcher.out_queue[index].records))
+                            index_found = index
+                            records_removed = True
+                            break
+                        
+                    if index_found != -1:
+                        del Batcher.out_queue[index_found]
+                        
+            if records_removed:
+                records_to_remove = 0
+            else:
+                records_to_remove = int(records_to_remove/2)  # Worst case we can't find 200 events to remove, try to remove less events
+        
+        return records_removed

--- a/ExtensionHandler/Linux/src/aria/batching_package.py
+++ b/ExtensionHandler/Linux/src/aria/batching_package.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from .bond_types import ClientToCollectorRequest, DataPackage
+from .utilities import AriaUtilities
+from .bond import AriaBondFast
+import sys
+
+class BatchingPackage(object):
+    def __init__(self, tenant, size):
+        self.tenant = tenant
+        self.package_to_serialize = ClientToCollectorRequest()
+        self.package_to_serialize.data_packages = [DataPackage()]
+        self.package_to_serialize.data_packages[0].data_package_id = AriaUtilities.generate_guid()
+        self.package_to_serialize.data_packages[0].source = "AST_Default_Source"
+        self.package_to_serialize.data_packages[0].timestamp = AriaUtilities.get_current_time_epoch_ms()
+        self.package_to_serialize.data_packages[0].schema_version = 1
+        self.package_to_serialize.data_packages[0].records = []
+        if sys.version_info[0] < 3:
+            self.serialized = ''
+        else:
+            self.serialized = b''
+        self.records = 0
+        self.records_list = []
+        self.size = size
+        self.max_size_reached = False
+        
+    def open_batching(self):
+        self.serialized = AriaBondFast.SerializeStart(self.package_to_serialize, self.records) + self.serialized
+    
+    def close_batching(self):
+        self.serialized += AriaBondFast.SerializeStop(self.package_to_serialize)

--- a/ExtensionHandler/Linux/src/aria/batching_record.py
+++ b/ExtensionHandler/Linux/src/aria/batching_record.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+from .bond import AriaBond
+
+class BatchingRecord(object):
+    def __init__(self, tenant):
+        self.tenant = tenant
+        self.record = b''
+        self.sequence_id = 0
+        self.bond_failed = False
+
+    def batch_record(self):
+        self.record = AriaBond.serialize_static(self.record)
+        self.size = len(self.record)
+        

--- a/ExtensionHandler/Linux/src/aria/bond.py
+++ b/ExtensionHandler/Linux/src/aria/bond.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+from .compact_binary_protocol import CompactBinaryProtocolWriter
+from . import bond_writers
+from threading import RLock
+from .log_config import AriaLog
+from sys import exc_info
+
+class AriaBond(object):
+    writer = None
+    serial = None
+    initialized = False
+    serialize_lock = RLock()
+    
+    def __init__(self):
+        self.writer = CompactBinaryProtocolWriter()
+        self.serial = bond_writers.BondSerializer()
+        self.writer_lock = RLock()
+    
+    def serialize(self, record):
+        serialized_record_buffer = self.serial.Serialize(self.writer, record)
+        self.serial.EmptyBuffer(self.writer)
+        return serialized_record_buffer
+
+    @staticmethod
+    def init_static():
+        with AriaBond.serialize_lock:
+            if AriaBond.initialized == False:
+                AriaBond.writer = CompactBinaryProtocolWriter()
+                AriaBond.serial = bond_writers.BondSerializer()
+                AriaBond.initialized = True
+        
+    @staticmethod
+    def serialize_static(record):
+        with AriaBond.serialize_lock:
+            serialized_record_buffer = AriaBond.serial.Serialize(AriaBond.writer, record)
+            AriaBond.serial.EmptyBuffer(AriaBond.writer)
+            return serialized_record_buffer
+    
+    def serialize_size(self, record):
+        with AriaBond.serialize_lock:
+            serialized_record_size = self.serial.SerializeSize(self.writer, record)
+            self.serial.EmptyBuffer(self.writer)
+            return serialized_record_size
+    
+        
+class AriaBondFast(object):    
+    writer = CompactBinaryProtocolWriter()
+    serial = bond_writers.BondSerializer()
+    writer_lock = RLock()
+    
+    @staticmethod
+    def SerializeStart(record, records_count):
+        try:
+            with AriaBondFast.writer_lock:
+                AriaBondFast.serial.SerializeClientToCollectorRequestStart(AriaBondFast.writer, record, records_count, False)
+                serialized_record_buffer = AriaBondFast.serial.GetOutput(AriaBondFast.writer)
+                AriaBondFast.serial.EmptyBuffer(AriaBondFast.writer)
+                return serialized_record_buffer
+        except:
+            AriaLog.aria_log.warning("SerializeStart failed" + str(exc_info()[0]))
+
+    @staticmethod
+    def SerializeStop(record):
+        try:
+            with AriaBondFast.writer_lock:
+                serialized_record_buffer = AriaBondFast.serial.SerializeDataPackageStartEnd(AriaBondFast.writer, record, False)
+                serialized_record_buffer = AriaBondFast.serial.GetOutput(AriaBondFast.writer)
+                AriaBondFast.serial.EmptyBuffer(AriaBondFast.writer)
+                
+                AriaBondFast.serial.SerializeClientToCollectorRequestEnd(AriaBondFast.writer, record, False)
+                serialized_record_buffer += AriaBondFast.serial.GetOutput(AriaBondFast.writer)
+                AriaBondFast.serial.EmptyBuffer(AriaBondFast.writer)
+                return serialized_record_buffer
+        except:
+            AriaLog.aria_log.warning("SerializeStop failed" + str(exc_info()[0]))
+
+def SerializeEvents(record_list):
+    try:
+        CompactBinaryProtocolWriter.InitGenerated()
+        AriaBond.init_static()
+    except:
+        for record in record_list:
+            record.bond_failed = True
+        return record_list
+    
+    for batching_record in record_list:
+        try:
+            batching_record.batch_record()
+        except:
+            batching_record.bond_failed = True
+    return record_list

--- a/ExtensionHandler/Linux/src/aria/bond_types.py
+++ b/ExtensionHandler/Linux/src/aria/bond_types.py
@@ -1,0 +1,61 @@
+class User(object):
+    def __init__(self, username = "" , ui_version = ""):
+        self.username = username
+        self.ui_version = ui_version
+               
+class PII(object):
+    def __init__(self, scrub_type = 0, kind = 0, raw_content = ""):
+        self.scrub_type = scrub_type
+        self.kind = kind
+        self.raw_content = raw_content
+        
+class Record(object):
+    def __init__(self, 
+                 record_id = "", \
+                 timestamp = 0,
+                 configuration_ids = None,
+                 record_type_str = "",
+                 event_type = "",
+                 extension = None,
+                 context_ids = None,
+                 initiating_user_composite = None,
+                 record_type_int = 0,
+                 pii_extensions = None):
+        self.record_id = record_id
+        self.timestamp = timestamp
+        self.configuration_ids = configuration_ids
+        self.type = record_type_str
+        self.event_type = event_type
+        self.extension = extension
+        self.context_ids = context_ids
+        self.initiating_user_composite = initiating_user_composite
+        self.record_type_int = record_type_int
+        self.pii_extensions = pii_extensions
+        
+class DataPackage(object):
+    def __init__(self,
+                 data_package_type = "", \
+                 source = "", \
+                 version = "", \
+                 ids = None, \
+                 data_package_id = "", \
+                 timestamp = 0, \
+                 schema_version = 0, \
+                 records = None):
+        self.data_package_type = data_package_type
+        self.source = source
+        self.version = version
+        self.ids = ids
+        self.data_package_id = data_package_id
+        self.timestamp = timestamp
+        self.schema_version = schema_version
+        self.records = records
+    
+class ClientToCollectorRequest(object):
+    def __init__(self,
+                 data_packages = None, \
+                 request_retry_count = 0):
+        self.data_packages = data_packages
+        self.request_retry_count = request_retry_count
+    
+    

--- a/ExtensionHandler/Linux/src/aria/bond_writers.py
+++ b/ExtensionHandler/Linux/src/aria/bond_writers.py
@@ -1,0 +1,231 @@
+from __future__ import absolute_import
+from .bond_types import *
+from .compact_binary_protocol import *
+import sys
+
+class BondSerializer(object):
+    
+    def SerializeUser(self, writer, value, is_base):
+        
+        if value.username != "":
+            writer.WriteFieldBegin(9, 1, None)
+            writer.WriteString(value.username)
+            
+        if value.ui_version != "":
+            writer.WriteFieldBegin(9, 3, None)
+            writer.WriteString(value.ui_version)
+        
+        writer.WriteStructEnd(is_base)
+    
+    def SerializePII(self, writer, value, is_base):
+        
+        if value.scrub_type != 0:
+            writer.WriteFieldBegin(16, 1, None)
+            writer.WriteInt32(value.scrub_type)
+            
+        if value.kind != 0:
+            writer.WriteFieldBegin(16, 2, None)
+            writer.WriteInt32(value.kind)
+        
+        if value.raw_content != 0:
+            writer.WriteFieldBegin(9, 3, None)
+            writer.WriteString(value.raw_content)
+                
+        writer.WriteStructEnd(is_base)
+    
+    def SerializeRecord(self, writer, value, is_base):
+    
+        if value.record_id != 0:
+            writer.WriteFieldBegin(9 , 1, None)
+            writer.WriteString(value.record_id)
+    
+        if value.timestamp != 0:
+            writer.WriteFieldBegin(17 , 3, None)
+            writer.WriteInt64(value.timestamp)
+    
+        if value.configuration_ids != None and len(value.configuration_ids) != 0:
+            writer.WriteFieldBegin(13 , 4, None)
+            writer.WriteMapContainerBegin(len(value.configuration_ids), 9 , 9 )
+            for item in value.configuration_ids:
+                writer.WriteString(item)
+                writer.WriteString(value.configuration_ids[item])
+    
+        if value.type != "":
+            writer.WriteFieldBegin(9 , 5, None)
+            writer.WriteString(value.type)
+        
+        if value.event_type != "":
+            writer.WriteFieldBegin(9 , 6, None)
+            writer.WriteString(value.event_type)
+    
+        if value.extension != None and len(value.extension) != 0:
+            writer.WriteFieldBegin(13 , 13, None)
+            writer.WriteMapContainerBegin(len(value.extension), 9 , 9 )
+            for item in value.extension:
+                writer.WriteString(item)
+                writer.WriteString(value.extension[item])
+        
+        if value.context_ids != None and len(value.context_ids) != 0:
+            writer.WriteFieldBegin(13 , 19, None)
+            writer.WriteMapContainerBegin(len(value.context_ids), 9 , 9 )
+            for item in value.context_ids:
+                writer.WriteString(item)
+                writer.WriteString(value.context_ids[item])
+    
+        if value.initiating_user_composite != None:
+            writer.WriteFieldBegin(10 , 21, None)
+            self.__Serialize(writer, value.initiating_user_composite, False)
+    
+        if value.record_type_int != 0:
+            writer.WriteFieldBegin(16 , 24, None)
+            writer.WriteInt32(value.record_type_int)
+    
+        if value.pii_extensions != None and len(value.pii_extensions) != 0:
+            writer.WriteFieldBegin(13 , 30, None)
+            writer.WriteMapContainerBegin(len(value.pii_extensions), 9 , 10 )
+            for item in value.pii_extensions:
+                writer.WriteString(item)
+                self.__Serialize(writer, value.pii_extensions[item], False)
+            
+        writer.WriteStructEnd(is_base)
+    
+    def SerializeDataPackage(self, writer, value, is_base):
+    
+        if value.data_package_type != "":
+            writer.WriteFieldBegin(9, 1, None)
+            writer.WriteString(value.data_package_type)
+    
+        if value.source != "":
+            writer.WriteFieldBegin(9, 2, None)
+            writer.WriteString(value.source)
+    
+        if value.version != "":
+            writer.WriteFieldBegin(9, 3, None)
+            writer.WriteString(value.version)
+    
+        if value.ids != None and len(value.ids) != 0:
+            writer.WriteFieldBegin(13, 4, None)
+            writer.WriteMapContainerBegin(len(value.ids), 9 , 9)
+            for item in value.ids:
+                writer.WriteString(item)
+                writer.WriteString(value.ids[item])
+            writer.WriteContainerEnd()
+    
+        if value.data_package_id != "":
+            writer.WriteFieldBegin(9, 5, None)
+            writer.WriteString(value.data_package_id)
+    
+        if value.timestamp != 0:
+            writer.WriteFieldBegin(17 , 6, None)
+            writer.WriteInt64(value.timestamp)
+    
+        if value.schema_version != 0:
+            writer.WriteFieldBegin(16, 7, None)
+            writer.WriteInt32(value.schema_version)
+    
+        if value.records != None and len(value.records) != 0:
+            writer.WriteFieldBegin(11, 8, None)
+            writer.WriteContainerBegin(len(value.records), 10 )
+            for item in value.records:
+                self.__Serialize(writer, item, False)
+    
+        writer.WriteStructEnd(is_base)
+    
+    def SerializeClientToCollectorRequest(self, writer, value, is_base):
+    
+        if value.data_packages != None:
+            writer.WriteFieldBegin(11 , 1, None)
+            writer.WriteContainerBegin(len(value.data_packages), 10 )
+            for item in value.data_packages:
+                self.__Serialize(writer, item, False)
+    
+        if value.request_retry_count != 0:
+            writer.WriteFieldBegin(16 , 2, None)
+            writer.WriteInt32(value.request_retry_count)
+    
+        writer.WriteStructEnd(is_base)
+        
+    def SerializeClientToCollectorRequestStart(self, writer, value, records, is_base):
+        if value.data_packages != None:
+            writer.WriteFieldBegin(11 , 1, None)
+            writer.WriteContainerBegin(len(value.data_packages), 10 )
+            for item in value.data_packages:
+                self.SerializeDataPackageStart(writer, item, records, False)
+    
+    def SerializeClientToCollectorRequestEnd(self, writer, value, is_base):
+        if value.request_retry_count != 0:
+            writer.WriteFieldBegin(16 , 2, None)
+            writer.WriteInt32(value.request_retry_count)
+    
+        writer.WriteStructEnd(is_base)
+    
+    def SerializeDataPackageStart(self, writer, value, records, is_base):    
+        if value.data_package_type != "":
+            writer.WriteFieldBegin(9 , 1, None)
+            writer.WriteString(value.data_package_type)
+    
+        if value.source != "":
+            writer.WriteFieldBegin(9 , 2, None)
+            writer.WriteString(value.source)
+    
+        if value.version != "":
+            writer.WriteFieldBegin(9 , 3, None)
+            writer.WriteString(value.version)
+    
+        if value.ids != None and len(value.ids) != 0:
+            writer.WriteFieldBegin(13 , 4, None)
+            writer.WriteMapContainerBegin(len(value.ids), 9 , 9)
+            for item in value.ids:
+                writer.WriteString(item)
+                writer.WriteString(value.ids[item])
+            writer.WriteContainerEnd()
+    
+        if value.data_package_id != "":
+            writer.WriteFieldBegin(9 , 5, None)
+            writer.WriteString(value.data_package_id)
+    
+        if value.timestamp != 0:
+            writer.WriteFieldBegin(17 , 6, None)
+            writer.WriteInt64(value.timestamp)
+    
+        if value.schema_version != 0:
+            writer.WriteFieldBegin(16 , 7, None)
+            writer.WriteInt32(value.schema_version)
+    
+        writer.WriteFieldBegin(11 , 8, None)
+        writer.WriteContainerBegin(records, 10 )
+    
+    def SerializeDataPackageStartEnd(self, writer, value, is_base):
+        writer.WriteStructEnd(is_base)
+    
+    def __Serialize(self, writer, value, is_base):
+        {
+        'User' : self.SerializeUser,
+        'AriaBondTypes.User' : self.SerializeUser,
+        'PII': self.SerializePII,
+        'AriaBondTypes.PII': self.SerializePII,
+        'Record': self.SerializeRecord,
+        'AriaBondTypes.Record': self.SerializeRecord,
+        'DataPackage': self.SerializeDataPackage,
+        'AriaBondTypes.DataPackage': self.SerializeDataPackage,
+        'ClientToCollectorRequest': self.SerializeClientToCollectorRequest,
+        'AriaBondTypes.ClientToCollectorRequest': self.SerializeClientToCollectorRequest
+        }[type(value).__name__](writer, value, is_base)
+
+    def SerializeSize(self, writer, value, is_base = False):
+        self.__Serialize(writer, value, is_base)
+        return len(writer._output) + writer._output_string_size
+    
+    def Serialize(self, writer, value, is_base = False):
+        self.__Serialize(writer, value, is_base)
+        return self.GetOutput(writer)
+    
+    def GetOutput(self, writer):
+        if sys.version_info[0] < 3:
+            return ''.join(str(chr(i)) if (type(i) != str and type(i) != bytes) else i for i in writer._output)
+        else:
+            return b''.join(bytes(chr(i) if type(i) != str else i, 'latin1') if type(i) != bytes else  i for i in writer._output)
+        
+    def EmptyBuffer(self, writer):
+        del writer._output[:]
+        writer._output_string_size = 0

--- a/ExtensionHandler/Linux/src/aria/client_message_type.py
+++ b/ExtensionHandler/Linux/src/aria/client_message_type.py
@@ -1,0 +1,3 @@
+class ClientMessageType(object):
+    ClientEvent = 1
+    ClientAggregate = 2

--- a/ExtensionHandler/Linux/src/aria/compact_binary_protocol.py
+++ b/ExtensionHandler/Linux/src/aria/compact_binary_protocol.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import
+import sys
+
+class CompactBinaryProtocolWriter(object):
+	write_file_map = {}
+	write_var_uint_map = {}
+	write_var_int_map = {}
+	write_var_int_map_limit = 2000
+	initialized = False
+	
+	def __init__(self):
+		self._output = []
+		self._output_string_size = 0
+		
+	@staticmethod
+	def InitGenerated():
+		if CompactBinaryProtocolWriter.initialized == False:
+			CompactBinaryProtocolWriter.WriteFiledBeginGenerate()
+			CompactBinaryProtocolWriter.WriteVarUIntGenerate()
+			CompactBinaryProtocolWriter.WriteVarIntGenerate()
+			CompactBinaryProtocolWriter.initialized = True
+			
+	@staticmethod
+	def WriteFiledBeginGenerate():
+		for field_type in range(0,256):
+			for field_id in range(0,40):
+				result = []
+				if field_id <= 5:
+					result.append(field_type | (field_id << 5))
+				elif field_id <= 0xff:
+					result.append(field_type | (6 << 5));
+					result.append(field_id & 255)
+				else:
+					result.append(field_type | ( 7 << 5 ))
+					result.append(field_id & 255)
+					result.append(field_id >> 8)
+					
+				CompactBinaryProtocolWriter.write_file_map[(field_type, field_id)] = result
+	
+	@staticmethod
+	def WriteVarIntGenerate():
+		for i in range(CompactBinaryProtocolWriter.write_var_int_map_limit):
+			value = i
+			result = []
+			value = (value << 1) ^ (value >> 31)
+			while value > 127:
+				result.append((value & 127) | 128);
+				value = value >> 7
+			result.append(value & 127)
+			CompactBinaryProtocolWriter.write_var_int_map[i] = result
+	
+	@staticmethod
+	def WriteVarUIntGenerate():
+		for i in range(CompactBinaryProtocolWriter.write_var_int_map_limit):
+			value = i
+			result = []
+			while value > 127:
+				result.append((value & 127) | 128);
+				value = value >> 7
+			result.append(value & 127)
+			CompactBinaryProtocolWriter.write_var_uint_map[i] = result
+	
+	def WriteFieldBegin(self, field_type, field_id, metadata = None):
+		self._output += CompactBinaryProtocolWriter.write_file_map[(field_type, field_id)]
+	
+	
+	def WriteVarInt(self, value):
+		while value > 127:
+			self._output.append((value & 127) | 128);
+			value = value >> 7
+		self._output.append(value & 127)
+	
+	def WriteInt32(self, value):
+		if value < CompactBinaryProtocolWriter.write_var_int_map_limit:
+			self._output += CompactBinaryProtocolWriter.write_var_int_map[value]
+		else:
+			value = (value << 1) ^ (value >> 31)
+			while value > 127:
+				self._output.append((value & 127) | 128);
+				value = value >> 7
+			self._output.append(value & 127)
+	
+	def WriteUInt32(self, value):
+		if value < CompactBinaryProtocolWriter.write_var_int_map_limit:
+			self._output += CompactBinaryProtocolWriter.write_var_uint_map[value]	
+		else:
+			while value > 127:
+				self._output.append((value & 127) | 128);
+				value = value >> 7
+			self._output.append(value & 127)
+	
+	def WriteString(self, string):
+		if sys.version_info[0] < 3:
+			if type(string) == unicode:
+				string = string.encode('utf8')
+			
+		if string == "":
+			self.WriteUInt32(0)
+		else:
+			self.WriteUInt32(len(string))
+			self._output.append(string)
+			self._output_string_size += len(string)
+	
+	def WriteContainerBegin(self, size, element_type):
+		self._output.append(element_type)
+		self.WriteUInt32(size)
+	
+	def WriteMapContainerBegin(self, size, key_type, value_type):
+		self._output.append(key_type)
+		self._output.append(value_type)
+		self.WriteUInt32(size)
+	
+	def WriteStructEnd(self, is_base):
+		self._output.append(1 if is_base == True else 0)
+	
+	def WriteUInt64(self, value):
+		self.WriteVarInt(value)
+	
+	def WriteInt64(self, value):
+		self.WriteUInt64((value << 1) ^ (value >> 63))
+	
+	def WriteBlob(self, value):
+		self._output.append(1 if value == True else 0 )
+	

--- a/ExtensionHandler/Linux/src/aria/configuration.py
+++ b/ExtensionHandler/Linux/src/aria/configuration.py
@@ -1,0 +1,31 @@
+from .configuration_impl import LogManagerConfigurationImpl
+import multiprocessing
+
+class LogManagerConfiguration(object):
+    def __init__(self, tcp_connections = 3
+                     , max_events_to_batch = 200
+                     , max_events_in_memory = 40000
+                     , log_configuration = None
+                     , drop_event_if_max_is_reached = True
+                     , batching_threads_count = multiprocessing.cpu_count()
+                     , all_threads_daemon = False):
+        """!@brief Creates a new LogManagerConfiguration object.
+
+            This LogManagerConfiguration is being used to configurate LogManager
+
+            @param tcp_connections Number of TCP connections we create, there will be a thread per TCP connection
+            @param max_events_in_memory Maximum number of events in memory at any point.
+            @param max_events_to_batch Maximum number of events that are batched together.
+            @param log_configuration LogConfiguration for Debugging purposes
+            @param drop_event_if_max_is_reached If this is True, old events are dropped to make space for the the new event. If it's false, the latest event is dropped.
+            @param batching_threads_count Number of batching threads.
+            @param all_threads_daemon Set up all the threads that are created as Daemon or not.
+        """
+        self.__implementation = LogManagerConfigurationImpl(tcp_connections, 
+                                                            max_events_to_batch,
+                                                            max_events_in_memory,
+                                                            log_configuration,
+                                                            drop_event_if_max_is_reached,
+                                                            batching_threads_count,
+                                                            all_threads_daemon)
+       

--- a/ExtensionHandler/Linux/src/aria/configuration_impl.py
+++ b/ExtensionHandler/Linux/src/aria/configuration_impl.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+from .log_config import LogConfiguration
+from .configuration_limits import ConfiguationLimits
+import multiprocessing
+
+class LogManagerConfigurationImpl(object):
+    def __init__(self, tcp_connections
+                     , max_events_to_batch
+                     , max_events_in_memory
+                     , log_configuration
+                     , drop_event_if_max_is_reached
+                     , batching_threads_count
+                     , all_threads_daemon):
+        if log_configuration == None:
+            log_configuration = LogConfiguration()
+
+        # Prechecks:
+        if tcp_connections > ConfiguationLimits.MAX_TCP_CONNECTION_ALLOWED or tcp_connections < ConfiguationLimits.MIN_TCP_CONNECTION_ALLOWED:
+            raise Exception("TCP Connection can't be higher than " + str(ConfiguationLimits.MAX_TCP_CONNECTION_ALLOWED) +
+                            " or lower than " + str(ConfiguationLimits.MIN_TCP_CONNECTION_ALLOWED))
+        
+        self.DROP_EVENT_IF_MAX_IS_REACHED = drop_event_if_max_is_reached
+        self.log_configuration = log_configuration
+        self.MAX_EVENTS_IN_MEMORY = max_events_in_memory
+        self.BATCHER_TIMER = 0.050                          # ms
+        self.SENDER_TIMER = 0.100                           # ms
+        self.SENDER_LAZY_TIMER = 10                         # Seconds
+        self.LAZY_BATCHER_TIMER = 10                        # Seconds
+        self.MAX_EVENTS_TO_BATCH = max_events_to_batch
+        self.TCP_CONNECTIONS = tcp_connections
+        self.ARIA_SENDER_TIMER = 0.050
+        self.SUPPORT_GZIP = True
+        self.MAX_SIZE_ALLOWED = 3 * 1024 * 1024 - 5 * 1024   # 5KB Safe margin
+        self.QUEUE_DROPPED_EVENTS = int(min(max_events_to_batch/10, 200))
+        self.MAX_RETRY_COUNT = 4
+        self.STATS_CADENCE = 3 * 60                                     # 5 minutes between stats
+        self.PROCESS_NUMBER = batching_threads_count                      # If this is set up to 0 then BATCHING_THREADS will be used to set up the threads
+        self.ALL_THREADS_DEAMON = all_threads_daemon

--- a/ExtensionHandler/Linux/src/aria/configuration_limits.py
+++ b/ExtensionHandler/Linux/src/aria/configuration_limits.py
@@ -1,0 +1,3 @@
+class ConfiguationLimits(object):
+    MAX_TCP_CONNECTION_ALLOWED = 6
+    MIN_TCP_CONNECTION_ALLOWED = 1

--- a/ExtensionHandler/Linux/src/aria/event_properties.py
+++ b/ExtensionHandler/Linux/src/aria/event_properties.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+import re
+from .pii import PiiKind
+from .client_message_type import ClientMessageType
+import sys
+    
+class EventProperties(object):
+    """!
+    @brief Class that has all key value pairs that represents an Record
+    """
+    def __init__(self, name):       
+        from .utilities import AriaUtilities
+        if (re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9_]){2,98}[a-zA-Z0-9]$").match(name)):
+            self.name = name
+        else:
+            raise ValueError("Invalid event name")
+        self.__time_stamp_in_epoch_ms = AriaUtilities.get_current_time_epoch_ms()        
+        self.__message_type = ClientMessageType.ClientEvent
+        self.__properties = {}
+        self.__pii_properties = {}
+        
+    def set_property(self, key, value, piiKind = PiiKind.PiiKind_None):
+        """!
+        @brief Sets the given key, value pair to the property bag
+        @param key Name of the property (\b str)
+        @param value Value of the property (\b str)
+        @param piiKind PiiKind of the property (\b PiiKind)
+        @see @ref aria.pii.PiiKind "PiiKind"
+        """
+        if (piiKind == PiiKind.PiiKind_None):
+            if sys.version_info[0] < 3:
+                self.__properties[key] = str(value) if type(value) != unicode else value
+            else:
+                self.__properties[key] = str(value) if type(value) != str else value
+                try:
+                    self.__properties[key] = bytes(self.__properties[key], 'latin1')
+                except:
+                    self.__properties[key] = self.__properties[key].encode('utf8')
+                    self.__properties[key] = ''.join(chr(i) for i in self.__properties[key])
+                    self.__properties[key] = bytes(self.__properties[key], 'latin1')
+        else:
+            if sys.version_info[0] < 3:
+                self.__pii_properties[key] = (value, piiKind)
+            else:
+                newValue = str(value) if type(value) != str else value
+                try:
+                    newValue = bytes(newValue, 'latin1')
+                except:
+                    newValue = newValue.encode('utf8')
+                    newValue = ''.join(chr(i) for i in newValue)
+                    newValue = bytes(newValue, 'latin1')
+                self.__pii_properties[key] = (newValue, piiKind)
+        
+    def __get_properties(self):
+        return self.__properties
+    
+    def __get_pii_properties(self):
+        return self.__pii_properties

--- a/ExtensionHandler/Linux/src/aria/extension.py
+++ b/ExtensionHandler/Linux/src/aria/extension.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+from .utilities import AriaUtilities
+
+class AriaExtension(object):
+    def __init__(self, source, name, init_id, sequence_id, time_stamp):
+        self.name = name
+        self.source = source if source else "Ast_Default_Source"
+        self.init_id = init_id
+        self.sequence_id = sequence_id
+        self.time_stamp = time_stamp
+        self.properties = {}
+   
+    def get_bond_object(self):
+        extension = {}
+
+        extension["EventInfo.Source"] = self.source
+        extension["EventInfo.Name"] = self.name
+        extension["EventInfo.Time"] = AriaUtilities.convert_ms_to_isoformat(self.time_stamp)
+        extension["EventInfo.InitId"] = self.init_id
+        extension["EventInfo.Sequence"] = str(self.sequence_id)
+        
+        for key, value in self.properties.items():
+            extension[key] = value
+
+        return extension
+    
+    @staticmethod
+    def get_bond(source, name, init_id, sequence_id, time_stamp, properties):
+        extension = {}
+        extension["EventInfo.Source"] = source if source else "Ast_Default_Source"
+        extension["EventInfo.Name"] = name
+        extension["EventInfo.Time"] = AriaUtilities.convert_ms_to_isoformat(time_stamp)
+        extension["EventInfo.InitId"] = init_id
+        extension["EventInfo.Sequence"] = str(sequence_id)
+        
+        for key, value in properties.items():
+            extension[key] = value
+
+        return extension

--- a/ExtensionHandler/Linux/src/aria/log_config.py
+++ b/ExtensionHandler/Linux/src/aria/log_config.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import
+import time
+from threading import RLock
+from logging import getLogger, handlers
+import logging
+from .aria_log import AriaLog
+            
+class LogConfiguration(object):
+    def __init__(self, log_level = logging.ERROR
+                 , file_prefix = 'aria.log'
+                 , file_max_size = 1024   # KB
+                 , backup_count = 1024
+                 , formatter = logging.Formatter("%(asctime)s [%(name)s][%(thread)d][%(process)d]:[%(levelname)s] %(filename)s:%(lineno)d %(message)s")
+                 , file_handler = handlers.RotatingFileHandler):
+        """!
+        @brief Constructor for LogConfigurtion that enables logging traces inside the SDK, This must be used for debug puruse only, not for production
+        @param log_level Minimum level of logging that will be printed (\b logging.ERROR for example)
+        @param file_prefix Prefix of the file used to save the traces. It will be fallowed by time.strftime("%d_%m_%Y_%H_%M") (\b str)
+        @param file_max_size Maximum size of the file in KB (\b int)
+        @param backup_count  Maximum number of backup count (\b int)
+        @param formatter Formatter used to print each trace. Change the default only if you know what you are doing and in debug mode only (\b logging.Formatter is an example)
+        @param file_handler Type of file handler wanted (\b logging.handlers  contains some fileHandlers)
+        """
+        self.file_name = file_prefix
+        self.log_level = log_level
+        self.file_name += time.strftime("%d_%m_%Y_%H_%M")
+        self.formatter = formatter
+        self.file_max_size =  file_max_size * 1024  # In B
+        self.backup_count = backup_count
+        self.file_handler = file_handler
+
+    @staticmethod
+    def __init_log(logConf):
+        from logging import handlers
+        import logging
+        if logConf.file_handler == handlers.RotatingFileHandler:
+            logConf.file_handler = handlers.RotatingFileHandler(logConf.file_name, maxBytes=logConf.file_max_size, backupCount=logConf.backup_count)
+            logConf.file_handler.setFormatter(logConf.formatter)
+        AriaLog.aria_log.addHandler(logConf.file_handler)
+        AriaLog.aria_log.setLevel(logConf.log_level)

--- a/ExtensionHandler/Linux/src/aria/log_manager.py
+++ b/ExtensionHandler/Linux/src/aria/log_manager.py
@@ -1,0 +1,68 @@
+from aria.log_manager_impl import LogManagerImpl
+
+class LogManager(object):
+    """!
+    @brief Log Manager static class manages the telemetry logging system
+    """
+    __implementation = LogManagerImpl
+
+    @staticmethod
+    def initialize(tenantToken, log_manager_conf = None):
+        """!
+        @brief Initializes the telemetry logging system with the specified tenant token and custom cofiguration.
+
+        @param tenantToken Default tenant token that will be used when GetLogger() is called (\b str)
+        @param log_manager_conf Configuration that will be used for the duration of the process (\b LogManagerConfiguration)
+        @return  The logger that has the tenantToken menetioned 
+        @see @ref aria.configuration.LogManagerConfiguration "LogManagerConfiguration"
+        """
+        return LogManager._LogManager__implementation.initialize(tenantToken, log_manager_conf)
+
+    @staticmethod
+    def add_subscriber(subscriber):
+        """!
+        @brief Adding a subscriber to the sdk events list
+        @param subscriber: Metod that has 3 parameters, the tenant token string, a list of events ID and the result for all the events
+        """
+        LogManager._LogManager__implementation.add_subscriber(subscriber)
+    
+    @staticmethod
+    def remove_subscriber(subscriber):
+        """!
+        @brief Removes one of the subscriber
+        @param subscriber The subscriber that is wanted to be removed
+        """
+        LogManager._LogManager__implementation.remove_subscriber(subscriber)
+        
+    @staticmethod
+    def remove_all_subscriber():
+        """!
+        @brief Remove all subscribers
+        """
+        LogManager._LogManager__implementation.remove_all_subscriber()
+    
+    @staticmethod    
+    def get_logger(source="", tenantToken=""):
+        """!
+        @brief Returns the logger that has the source and the tenantToken mention, if it doesn't exist, it will create a new one
+        @param source Source for your tenat, it can also be empty (\b str)
+        @param tenantToken TenantToken to map your logger to a specified token (\b str)
+        @return  The logger that has the source and the tenantToken mention, if it doesn't exist, it will create a new one
+        @see @ref aria.logger.Logger "Logger"
+        """
+        return LogManager._LogManager__implementation.get_logger(source, tenantToken)
+            
+    @staticmethod
+    def flush(timeout = 10):
+        """!
+        @brief flush all the events in memory in the amount of time specified
+        @param timeout Time limit for the flush to end (\b int)
+        """
+        LogManager._LogManager__implementation.flush(timeout)
+
+    @staticmethod
+    def flush_and_tead_down():
+        """!
+        @brief It is called at the end to ensure all threads are stopped and all data is delated
+        """
+        LogManager._LogManager__implementation.flush_and_tead_down

--- a/ExtensionHandler/Linux/src/aria/log_manager_impl.py
+++ b/ExtensionHandler/Linux/src/aria/log_manager_impl.py
@@ -1,0 +1,262 @@
+from __future__ import absolute_import
+from threading import RLock
+from . import log_config
+from . import logger
+from . import configuration
+from .batcher import Batcher
+from . import sender
+from .compact_binary_protocol import CompactBinaryProtocolWriter
+from .bond import AriaBond
+import threading 
+from multiprocessing import Pool
+from .subscribe import Subscribe
+from .stats_manager import StatsManager
+import sys
+from aria.six.moves import range
+from .log_config import LogConfiguration
+
+class LogManagerImpl(object):
+    __loggers = {}       # list of loggers unique for the combination source, tenantToken
+    tenant_token = ""
+    logger_lock = RLock()
+    is_initialize = False
+    events_in_memory = 0
+    events_in_memory_lock = RLock()
+    configuration = None
+    log_manager_initializes = False
+    aria_sender_threads = []
+    pool_process = None
+    aria_bond = None
+    subscribers = None
+    stats_manager = None
+    is_flushed = False
+    flushed_called = False    
+    
+    @staticmethod
+    def __StartThreads():
+        ''' This method stats Batcher threads and sender threads '''
+        log_config.AriaLog.aria_log.info("Starting all threads")
+        Batcher.define_threads()
+        Batcher.start_sender_lazy_thread()
+        Batcher.start_batcher_thread()
+        Batcher.start_sender_thread()
+        
+        for index in range(LogManagerImpl.configuration.TCP_CONNECTIONS):
+            aria_sender = sender.AriaSender(index)
+            aria_sender.start_thread()
+            LogManagerImpl.aria_sender_threads.append(aria_sender)
+    
+    @staticmethod
+    def records_in_memory():
+        return LogManagerImpl.events_in_memory
+      
+    @staticmethod
+    def increment_events_in_memory(count = 1):
+        with LogManagerImpl.events_in_memory_lock:
+            LogManagerImpl.events_in_memory += count
+    
+    @staticmethod
+    def decrement_events_in_memory(count = 1):
+        with LogManagerImpl.events_in_memory_lock:
+            LogManagerImpl.events_in_memory -= count
+            if LogManagerImpl.events_in_memory < 0:
+                log_config.AriaLog.aria_log.warning("Number of events in memory is negative. Something is wrong.")
+        
+    @staticmethod
+    def initialize(tenantToken, log_manager_conf = None):
+        log_config.AriaLog.aria_log.info("LogManager Init was called!")
+        if log_manager_conf == None:
+            log_manager_conf = configuration.LogManagerConfiguration()
+        # from AriaCore import init_log,aria_log
+        if LogManagerImpl.is_initialize == True:
+            return
+        
+        from .stats_manager import StatsConstants, StatsManager
+        if LogManagerImpl.is_initialize == False:
+            try:
+                with LogManagerImpl.logger_lock:
+                    # Initialize the log_manager
+                    LogManagerImpl.configuration = log_manager_conf._LogManagerConfiguration__implementation
+                    LogConfiguration._LogConfiguration__init_log(LogManagerImpl.configuration.log_configuration)
+                    
+                    # Init the subscribers
+                    LogManagerImpl.subscribers = Subscribe()
+                    
+                    # Init the aria bond for better performance
+                    CompactBinaryProtocolWriter.InitGenerated()
+                    
+                    # copy the tenant_token
+                    LogManagerImpl.tenant_token = tenantToken
+                    
+                    # Get the logger
+                    logger =  LogManagerImpl.__create_or_get_logger("", LogManagerImpl.tenant_token)
+                    
+                    # Populate the sdk for the stats
+                    StatsConstants().PopulateSDKVersion()
+                    
+                    # Start the threads for sending events and batcher
+                    LogManagerImpl.__StartThreads()
+                    
+                    # Define the stats manager for Log Manager
+                    LogManagerImpl.stats_manager = StatsManager()
+                    
+                    # Initialize a static instance of Aria BOnd
+                    AriaBond.init_static()
+                    
+                    # Create a poll process for the LogManager to be used for serializing the events
+                    if LogManagerImpl.configuration.PROCESS_NUMBER > 0:
+                        LogManagerImpl.pool_process = Pool(LogManagerImpl.configuration.PROCESS_NUMBER)
+                    
+                    # Create an instance of Aria Bond for the log_manager
+                    LogManagerImpl.aria_bond = AriaBond()
+                    
+                    #Specify that the initialze was completed
+                    LogManagerImpl.is_initialize = True
+                    
+                    log_config.AriaLog.aria_log.info("Intialize completed successfuly ")
+                    return logger
+            except:
+                log_config.AriaLog.aria_log.error("Error while initialize the LogManager:" + str(sys.exc_info()[0]))
+                LogManagerImpl.is_initialize = False
+                pass
+    
+    @staticmethod
+    def add_subscriber(subscriber):
+        log_config.AriaLog.aria_log.info("subscriber added")
+        if LogManagerImpl.is_initialize == False:
+            log_config.AriaLog.aria_log.debug("subscriber added failed")
+            return False
+        LogManagerImpl.subscribers.register(subscriber)
+    
+    @staticmethod
+    def remove_subscriber(subscriber):
+        log_config.AriaLog.aria_log.info("remove_subscriber")
+        if LogManagerImpl.is_initialize == False:
+            return False
+        try:
+            LogManagerImpl.subscribers.unregister(subscriber)
+            return True        
+        except:
+            log_config.AriaLog.aria_log.warning("remove_subscriber failed" + str(sys.exc_info()[0]))
+            return False
+    @staticmethod
+    def remove_all_subscriber():
+        log_config.AriaLog.aria_log.info("remove_all_subscriber")
+        if LogManagerImpl.is_initialize == False:
+            return None
+        try:
+            LogManagerImpl.subscribers.unregister_all()
+        except:
+            log_config.AriaLog.aria_log.warning("remove_all_subscribers failed"  + str(sys.exc_info()[0]))
+            return False
+    
+    @staticmethod    
+    def get_logger(source="", tenantToken=""):
+        log_config.AriaLog.aria_log.info("get_logger")
+        if LogManagerImpl.is_initialize == False:
+            return None
+        try:
+            with LogManagerImpl.logger_lock:
+                return LogManagerImpl.__create_or_get_logger(source, tenantToken)
+        except:
+            log_config.AriaLog.aria_log.warning("get_logger failed "  + str(sys.exc_info()[0]))
+            return None
+            
+    @staticmethod
+    def flush(timeout = 10):
+        if not LogManagerImpl.is_initialize:
+            return
+
+        from time import sleep
+        from .stats_manager import StatsConstants
+        log_config.AriaLog.aria_log.info("flush was called")
+        LogManagerImpl.stats_manager.flush_and_tead_down()
+        flushed_called = True
+        #try:
+        with LogManagerImpl.logger_lock:
+            
+            # Stop each logger to receive events
+            for i in LogManagerImpl.__loggers:
+                if LogManagerImpl.__loggers[i]._Logger__tenant_token != StatsConstants.stats_tenant_token:
+                    LogManagerImpl.__loggers[i]._Logger__flush()
+            
+            # Stop the batcher theards and process the remaining events
+            Batcher.flush()
+            timeout_packages = timeout
+            while LogManagerImpl.events_in_memory > 0  and timeout_packages > 0:
+                log_config.AriaLog.aria_log.debug(str(LogManagerImpl.events_in_memory) + " events in memory yet")
+                sleep(1)
+                timeout_packages -= 1
+            
+            # Send stats:
+            LogManagerImpl.stats_manager.flush()
+            Batcher.send_all_remaining_events()
+            
+            if timeout == 0:
+                timeout = 1
+            timeout_stats = timeout
+            while LogManagerImpl.events_in_memory > 0  and timeout_stats > 0:
+                log_config.AriaLog.aria_log.debug(str(LogManagerImpl.events_in_memory) + " events in memory yet")
+                sleep(1)
+                timeout_stats -= 1
+            
+            for i in LogManagerImpl.__loggers:
+                if LogManagerImpl.__loggers[i]._Logger__tenant_token == StatsConstants.stats_tenant_token:
+                    LogManagerImpl.__loggers[i]._Logger__flush()
+            
+            for aria_sender in LogManagerImpl.aria_sender_threads:
+                try:
+                    aria_sender.stop_thread()
+                except:
+                    pass
+            
+            if LogManagerImpl.configuration.PROCESS_NUMBER !=0:
+                LogManagerImpl.pool_process.close()
+            LogManagerImpl.is_flushed = True
+            
+            # Revert all the variables to start
+            LogManagerImpl.__loggers = {}
+            LogManagerImpl.tenant_token = ""
+            LogManagerImpl.logger_lock = RLock()
+            LogManagerImpl.is_initialize = False
+            LogManagerImpl.events_in_memory = 0
+            LogManagerImpl.events_in_memory_lock = RLock()
+            LogManagerImpl.configuration = None
+            LogManagerImpl.log_manager_initializes = False
+            LogManagerImpl.aria_sender_threads = []
+            LogManagerImpl.pool_process = None
+            LogManagerImpl.aria_bond = None
+            LogManagerImpl.subscribers = None
+            LogManagerImpl.stats_manager = None
+            LogManagerImpl.is_flushed = False
+            log_config.AriaLog.aria_log.info("Flushed finished")
+        return True
+    
+    @staticmethod
+    def empty_the_system():
+        log_config.AriaLog.aria_log.info("empty_the_system was called")
+        Batcher.stop_and_clean_up()
+    
+    @staticmethod
+    def tear_down():
+        del LogManagerImpl.__loggers
+        
+    @staticmethod        
+    def flush_and_tead_down():
+        LogManagerImpl.flush()
+        LogManagerImpl.tear_down()
+    
+    @staticmethod
+    def __create_or_get_logger(source, tenantToken):
+        log_config.AriaLog.aria_log.info("Return a logger for tenant:" + tenantToken)
+        try:
+            if (source, tenantToken) in LogManagerImpl.__loggers:
+                logger_local = LogManagerImpl.__loggers[(source, tenantToken)]
+            else:
+                log_config.AriaLog.aria_log.info("Create a logger")
+                logger_local = logger.Logger(source, tenantToken)
+                LogManagerImpl.__loggers[(source, tenantToken)] = logger_local
+            return logger_local
+        except:
+            log_config.AriaLog.aria_log.warning("Create a logger " + str(sys.exc_info()[0]))
+            return None

--- a/ExtensionHandler/Linux/src/aria/logger.py
+++ b/ExtensionHandler/Linux/src/aria/logger.py
@@ -1,0 +1,111 @@
+from __future__ import absolute_import
+from . import event_properties
+from threading import RLock, Thread
+from .batcher import Batcher
+from .bond_types import Record
+from .extension import AriaExtension
+from .pii_extension import AriaPiiExtension
+from . import bond_types
+from .batching_record import BatchingRecord
+from sys import exc_info
+from .log_config import AriaLog
+from .utilities import AriaUtilities
+from .stats_manager import StatsConstants
+
+class EventDropReason(object):
+    """!
+    @brief Enum that represents reasons why an event was not added to the queue. This value is returned by LogEvent
+    """
+    EVENT_NOT_ADDED = -1
+    NO_EVENTS_ACCEPTED = -2
+    MAX_EVENTS_REACHED = -3
+    LOG_MANAGER_NOT_INITIALIZED = -4
+
+class Logger(object):
+    """!
+    @brief Class that allows logging events for a specific tenant
+    """
+
+    def __init__(self, source, tenantToken):
+        AriaLog.aria_log.info("Logger was initialized")
+        self.__source = source
+        self.__tenant_token = tenantToken.lower()
+        self.__sequence_id = 0
+        self.__init_id = AriaUtilities.generate_guid()
+        self.__log_event = RLock()
+        self.__lock_flush = RLock()
+        self.__is_flushed = False
+    
+    def log_event(self, arg):
+        """!
+        Logs an event property and sends it to the collector
+        @param arg \b EventProperties event_property that wants to be logged in.
+        @return \b EventDropReason or a number grated then 0 that represents the ID of the event. This ID will be returned in the callback for all subscribers alongisde with the status of the event
+        @see @ref aria.event_properties.EventProperties "EventProperties"
+        """
+        with self.__lock_flush:
+            from aria.log_manager import LogManagerImpl
+            if self.__is_flushed == True:
+                AriaLog.aria_log.debug("Log Event doesn't accept more events, flushed was called")
+                return EventDropReason.NO_EVENTS_ACCEPTED
+
+            if LogManagerImpl == None or not LogManagerImpl.is_initialize:
+                return EventDropReason.LOG_MANAGER_NOT_INITIALIZED
+
+            if LogManagerImpl != None and LogManagerImpl.records_in_memory() >= LogManagerImpl.configuration.MAX_EVENTS_IN_MEMORY:
+                if LogManagerImpl.configuration.DROP_EVENT_IF_MAX_IS_REACHED == False:
+                    AriaLog.aria_log.info("Log Event doesn't accept more events, maximum capacity reached")
+                    return EventDropReason.MAX_EVENTS_REACHED
+                else:
+                    AriaLog.aria_log.info("Events will be dropped now")
+                    dropped = Batcher.drop_events()
+                    if dropped == False:
+                        # We have to drop this event also
+                        AriaLog.aria_log.info("Log Event doesn't accept more events, maximum capacity reached")
+                        return EventDropReason.EVENT_NOT_ADDED
+                    # We have to drop events
+                    
+            sequence_id = 0
+            with self.__log_event:
+                self.__sequence_id += 1
+                sequence_id = self.__sequence_id
+            
+            if type(arg) is str:
+                self.__log_event_to_ariarecord(event_properties.EventProperties(arg),sequence_id)
+            elif type(arg) is event_properties.EventProperties:
+                self.__log_event_to_ariarecord(arg, sequence_id)
+            else:
+                raise TypeError("no match")
+            return sequence_id
+
+    def __flush(self):
+        with self.__lock_flush:
+            self.__is_flushed = True
+
+    def __tear_down(self):
+        del self
+    
+    def __log_event_to_ariarecord(self, event_properties,sequence_id):
+        from aria.log_manager import LogManagerImpl
+        batched_record = BatchingRecord(self.__tenant_token)
+        
+        batched_record.sequence_id = sequence_id
+        batched_record.record = bond_types.Record()
+        batched_record.record.record_id = AriaUtilities.generate_guid()
+        batched_record.record.type = "custom"
+        batched_record.record.event_type = event_properties.name
+        batched_record.record.record_type_int = event_properties._EventProperties__message_type
+        batched_record.record.timestamp = event_properties._EventProperties__time_stamp_in_epoch_ms
+        batched_record.record.extension = AriaExtension.get_bond("", 
+                                                                 batched_record.record.event_type, 
+                                                                 self.__init_id, self.__sequence_id, 
+                                                                 batched_record.record.timestamp, 
+                                                                 event_properties._EventProperties__get_properties())
+        pii_prop = event_properties._EventProperties__get_pii_properties()
+        
+        if (len(list(pii_prop.items())) > 0):
+            batched_record.record.pii_extensions = AriaPiiExtension.get_bond(pii_prop)
+
+        Batcher.add_record(self.__tenant_token, batched_record)
+        if StatsConstants.stats_tenant_token != self.__tenant_token:
+            LogManagerImpl.stats_manager.events_received(self.__tenant_token, 1)

--- a/ExtensionHandler/Linux/src/aria/package.py
+++ b/ExtensionHandler/Linux/src/aria/package.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from .utilities import AriaUtilities
+from .bond_types import DataPackage
+
+class AriaPackage(object):
+    def __init__(self, source="AST_Default_Source"):
+        self.datapackage_id = AriaUtilities.generate_guid()
+        self.source = source
+        self.time_stamp = AriaUtilities.get_utc_time()
+        self.schema_version = 1
+        self.records = []
+
+    def get_bond_object(self):
+        bond_package = DataPackage()
+        bond_package.data_package_id = self.datapackage_id
+        bond_package.source = self.source
+        bond_package.timestamp = AriaUtilities.get_current_time_epoch_ms()
+        bond_package.schema_version = self.schema_version
+        bond_package.records = self.records
+        return bond_package

--- a/ExtensionHandler/Linux/src/aria/pii.py
+++ b/ExtensionHandler/Linux/src/aria/pii.py
@@ -1,0 +1,18 @@
+class PiiKind(object):
+    """!
+    @brief The kind of Personal Identifiable Information (PII), as one of the enumeration values
+    """
+    PiiKind_None                = 0
+    PiiKind_DistinguishedName   = 1
+    PiiKind_GenericData         = 2
+    PiiKind_IPv4Address         = 3
+    PiiKind_IPv6Address         = 4
+    PiiKind_MailSubject         = 5
+    PiiKind_PhoneNumber         = 6
+    PiiKind_QueryString         = 7
+    PiiKind_SipAddress          = 8
+    PiiKind_SmtpAddress         = 9
+    PiiKind_Identity            = 10
+    PiiKind_Uri                 = 11
+    PiiKind_Fqdn                = 12
+    PiiKind_IPv4AddressLegacy   = 13

--- a/ExtensionHandler/Linux/src/aria/pii_extension.py
+++ b/ExtensionHandler/Linux/src/aria/pii_extension.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+from .bond_types import PII
+
+class AriaPiiExtension(object):
+    def __init__(self):
+        self.pii_properties = {}
+   
+    def get_bond_object(self):
+        piiExtension = {}
+        
+        for key, (value, piiKind) in self.pii_properties.items():
+            pii = PII()
+            pii.kind = piiKind
+            pii.raw_content = value
+            pii.scrub_type = 1
+            piiExtension[key] = pii
+            
+            return piiExtension
+    
+    @staticmethod
+    def get_bond(pii_properties):
+        piiExtension = {}
+        
+        for key, (value, piiKind) in pii_properties.items():
+            pii = PII()
+            pii.kind = piiKind
+            pii.raw_content = value
+            pii.scrub_type = 1
+            piiExtension[key] = pii
+            
+        return piiExtension
+

--- a/ExtensionHandler/Linux/src/aria/record.py
+++ b/ExtensionHandler/Linux/src/aria/record.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+from .bond_types import Record
+from .utilities import AriaUtilities
+from .extension import AriaExtension
+from .pii_extension import AriaPiiExtension
+
+class AriaRecord(object):
+    def __init__(self, eventType, type="custom", recordType=1):
+        self.id = AriaUtilities.generate_guid()
+        self.type = type
+        self.event_type = eventType
+        self.time_stamp = AriaUtilities.get_current_time_epoch_ms()
+        self.record_type = 1
+        self.properties = {}
+        self.pii_properties = {}
+        self.init_id = ""
+        self.sequence_id = 0
+        self.retry_count = 0
+
+    def get_bond_object(self):
+        bond_record = Record()
+        bond_record.record_id = self.id
+        bond_record.type = self.type
+        bond_record.event_type = self.event_type
+        bond_record.record_type_int = self.record_type
+        bond_record.timestamp = self.time_stamp
+        aria_extension = AriaExtension("", self.event_type, self.init_id, self.sequence_id, self.time_stamp)
+        aria_extension.properties = self.properties
+        bond_record.extension = aria_extension.get_bond_object()
+        
+        if (len(list(self.pii_properties.items())) > 0):
+            aria_pii_extension = AriaPiiExtension()
+            aria_pii_extension.pii_properties = self.pii_properties
+            bond_record.pii_extensions = aria_pii_extension.get_bond_object()
+
+        return bond_record

--- a/ExtensionHandler/Linux/src/aria/sender.py
+++ b/ExtensionHandler/Linux/src/aria/sender.py
@@ -1,0 +1,208 @@
+from __future__ import absolute_import
+from . import six
+#from six.moves.http_client import HTTPSConnection
+from aria.six.moves.http_client import HTTPSConnection
+import ssl
+import aria.log_manager
+from threading import Thread
+from time import sleep
+from . import batcher
+from . import utilities
+from threading import RLock
+import datetime
+from multiprocessing import Pool
+from .stats_manager import StatsConstants
+from random import randint
+from _random import Random
+from random import random
+from .log_config import AriaLog
+from sys import exc_info
+from .subscribe import SubscribeStatus
+import socket
+from aria.six.moves import range
+
+class AriaSender(object):
+    def __init__(self, sender_index):
+        AriaLog.aria_log.info("AriaSender was initialized")
+        try:
+            self.sender_index = sender_index
+            self.pipeline_url = "pipe.skype.com"
+            self.connection = HTTPSConnection(self.pipeline_url, timeout = 10)
+            
+            if hasattr(ssl, '_create_unverified_context'):
+                ssl._create_default_https_context = ssl._create_unverified_context
+                
+            self.run_thread_running = False
+            self.check_thread_running = False
+            self.run_thread = Thread(target = self.__run)
+            self.run_thread.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON
+            self.package_to_send = None
+            self.package_retry = 0  # TODO implement retry logic
+            self.package_size = 0
+            self.retry_count = aria.log_manager.LogManagerImpl.configuration.MAX_RETRY_COUNT
+            self.retry_seconds = [0,1]
+            for val in range(self.retry_count):
+                self.retry_seconds.append(self.retry_seconds[val + 1] * 2)
+                
+            self.initialiezed = True
+        except:
+            self.initialiezed = False
+            AriaLog.aria_log.warning("AriaSender failed to initialize" + str(exc_info()[0]))
+        
+    def start_thread(self):
+        AriaLog.aria_log.info("AriaSender " + "Sender" + str(self.sender_index) + " thread started")
+        if self.initialiezed == False:
+            return
+        self.run_thread_running = True
+        self.run_thread.start()
+            
+    def stop_thread(self):
+        if self.initialiezed == False:
+            return
+        
+        AriaLog.aria_log.info("AriaSender " + "Sender" + str(self.sender_index) + " thread stopped")
+        
+        self.run_thread_running = False 
+        self.run_thread.join()
+        
+    def __run(self):
+        if self.initialiezed == False:
+            return
+        
+        while self.run_thread_running == True:
+            try:
+                self.package_to_send = batcher.Batcher.remove_package_from_out()
+                if self.package_to_send != None:
+                    
+                    response = self.send_to_pipeline()
+                    
+                    if StatsConstants.stats_tenant_token != self.package_to_send.tenant: 
+                        aria.log_manager.LogManagerImpl.decrement_events_in_memory(self.package_to_send.records)
+                    
+                    if response == None: 
+                        aria.log_manager.LogManagerImpl.subscribers.update(self.package_to_send.tenant, self.package_to_send.records_list, SubscribeStatus.NO_INTERNET_CONNECTION)
+                        if aria.log_manager.LogManagerImpl.stats_manager != None:                        
+                            aria.log_manager.LogManagerImpl.stats_manager.events_dropped(self.package_to_send.tenant, self.package_to_send.records)
+                            aria.log_manager.LogManagerImpl.stats_manager.average_package_size(self.package_to_send.tenant, len(self.package_to_send.serialized))
+                            aria.log_manager.LogManagerImpl.stats_manager.average_record_size(self.package_to_send.tenant, len(self.package_to_send.serialized)/self.package_to_send.records)
+                        continue
+                    # Alert all the subscribers  
+                    aria.log_manager.LogManagerImpl.subscribers.update(self.package_to_send.tenant, self.package_to_send.records_list, response.status)
+                        
+                    if response.status == 200:
+                        if aria.log_manager.LogManagerImpl.stats_manager != None:
+                            aria.log_manager.LogManagerImpl.stats_manager.events_send(self.package_to_send.tenant, self.package_to_send.records)
+                            aria.log_manager.LogManagerImpl.stats_manager.total_data_send(self.package_to_send.tenant, len(self.package_to_send.serialized))
+                    else:
+                        if aria.log_manager.LogManagerImpl.stats_manager != None:
+                            aria.log_manager.LogManagerImpl.stats_manager.events_dropped(self.package_to_send.tenant, self.package_to_send.records)
+                            aria.log_manager.LogManagerImpl.stats_manager.records_dropped_status(self.package_to_send.tenant, self.package_to_send.records, response.status)
+                    
+                    if aria.log_manager.LogManagerImpl.stats_manager != None:                    
+                        aria.log_manager.LogManagerImpl.stats_manager.average_package_size(self.package_to_send.tenant, len(self.package_to_send.serialized))
+                        aria.log_manager.LogManagerImpl.stats_manager.average_record_size(self.package_to_send.tenant, len(self.package_to_send.serialized)/self.package_to_send.records)
+                    
+                    AriaLog.aria_log.debug("Sender" + str(self.sender_index) + " Package=1, Size=" + str(len(self.package_to_send.serialized)) + " Response=" + str(response.status) + " Records=" + str(self.package_to_send.records)) 
+                else:
+                    sleep(aria.log_manager.LogManagerImpl.configuration.ARIA_SENDER_TIMER)
+            except:
+                AriaLog.aria_log.warning("AriaSender has failed" + str(exc_info()[0]))
+                sleep(aria.log_manager.LogManagerImpl.configuration.ARIA_SENDER_TIMER)
+            if aria.log_manager.LogManagerImpl.flushed_called == True:
+                AriaLog.aria_log.info("Sender aria.LogManagerImpl.flushed_called")
+                self.run_thread_running = False
+                return
+
+    def send_to_pipeline(self):
+        send_tries = 0
+        close_connection = False
+        response = None
+        try:
+            while send_tries < self.retry_count:
+                retry_cause_found = False
+                if close_connection == True:
+                    close_connection = False
+                    self.connection.close()
+                    self.connection = HTTPSConnection(self.pipeline_url, timeout=10)
+                    AriaLog.aria_log.info("We had to start a new connection, old one was unusable")
+
+                try:
+                    if aria.log_manager.LogManagerImpl.configuration.SUPPORT_GZIP == True:
+                        out_buffer = utilities.AriaUtilities.gzip_compress(self.package_to_send.serialized)
+                    else:
+                        out_buffer = self.package_to_send_serialize
+                    aria.log_manager.LogManagerImpl.stats_manager.events_tried(self.package_to_send.tenant, self.package_to_send.records)
+                    
+                    headers = \
+                    {
+                        "Content-Type": "application/bond-compact-binary",
+                        "Client-Id": "NO_AUTH",
+                        "Connection":" keep-alive",
+                        "Expect": "100-continue",
+                        "Content-Length": str(len(out_buffer)),
+                        "x-apikey": self.package_to_send.tenant,
+                        "Sdk-version": StatsConstants.SDK_VERSION,
+                    }
+                    
+                    if aria.log_manager.LogManagerImpl.configuration.SUPPORT_GZIP == True:
+                        headers["Content-Encoding"] = "gzip"
+                
+                    try:
+                        self.connection.request('POST', 'https://' + self.pipeline_url + '/Collector/3.0/', out_buffer, headers)
+                    except:
+                        close_connection = True
+                        AriaLog.aria_log.info("Sender" + str(self.sender_index) + "Trying to send an event failed " + str(exc_info()[0]))
+                        aria.log_manager.LogManagerImpl.stats_manager.records_retry_status(self.package_to_send.tenant, self.package_to_send.records, AriaSender.create_event_name(str(exc_info()[0])))
+                        retry_cause_found = True
+                    finally:                
+                        try:
+                            response = self.connection.getresponse()
+                            response.read()
+                        except:
+                            response_error = AriaSender.create_event_name(str(exc_info()[0]))
+                            response = None    # We have to do this in order to reuse the connection. otherwise it will refuse all further connections 
+                        
+                    if response != None and response.status == 200:
+                        return response 
+                    else:
+                        if response != None:
+                            AriaLog.aria_log.debug("Sender" + str(self.sender_index) + "Retry because of status code " + str(response.status))
+                            aria.log_manager.LogManagerImpl.stats_manager.records_retry_status(self.package_to_send.tenant, self.package_to_send.records, response.status)
+                        elif retry_cause_found == False:
+                            aria.log_manager.LogManagerImpl.stats_manager.records_retry_status(self.package_to_send.tenant, self.package_to_send.records, response_error)
+                            
+                        aria.log_manager.LogManagerImpl.stats_manager.records_retry(self.package_to_send.tenant, self.package_to_send.records)
+                        send_tries += 1
+                        if send_tries < self.retry_count:
+                            sleep(self.retry_seconds[send_tries] * (0.8 + random() * 0.4))
+                except:
+                        AriaLog.aria_log.warning("Sender" + str(self.sender_index) + "Retry because of Error=" + str(exc_info()[0]))
+                        if aria.log_manager.LogManagerImpl.stats_manager != None:
+                            aria.log_manager.LogManagerImpl.stats_manager.records_retry(self.package_to_send.tenant, self.package_to_send.records)
+                            aria.log_manager.LogManagerImpl.stats_manager.records_retry_status(self.package_to_send.tenant, self.package_to_send.records, AriaSender.create_event_name(str(exc_info()[0])))
+                        send_tries += 1
+                        if send_tries < self.retry_count:
+                            sleep(self.retry_seconds[send_tries] * (0.8 + random() * 0.4))
+                            
+        except BaseException as e:
+            close_connection = True
+            AriaLog.aria_log.warning("Sender" + str(self.sender_index) + "Trying to send an event failed " + str(exc_info()[0]) + " message=" + str(e))
+        
+        if close_connection == True:
+            self.connection.close()
+            self.connection = HTTPSConnection(self.pipeline_url, timeout=10)
+            AriaLog.aria_log.info("We had to start a new connection, old one was unusable")
+            
+        return response
+    
+    @staticmethod
+    def create_event_name(string):
+        
+        try:
+            poz1 = string.find("\'")
+            poz2 = string[poz1 + 1:].find("\'")
+            string = string[poz1 + 1:poz1 + poz2 + 1]
+            string = string.replace(".", "_")
+            return string   
+        except:
+            return "request_error"

--- a/ExtensionHandler/Linux/src/aria/six.py
+++ b/ExtensionHandler/Linux/src/aria/six.py
@@ -1,0 +1,891 @@
+# Copyright (c) 2010-2017 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.11.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("getoutput", "commands", "subprocess"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("email_mime_image", "email.MIMEImage", "email.mime.image"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_to_bytes", "urllib", "urllib.parse", "unquote", "unquote_to_bytes"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("splitvalue", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+    MovedAttribute("parse_http_list", "urllib2", "urllib.request"),
+    MovedAttribute("parse_keqv_list", "urllib2", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    try:
+        raise tp, value, tb
+    finally:
+        tb = None
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        if from_value is None:
+            raise value
+        raise value from from_value
+    finally:
+        value = None
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(type):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+
+        @classmethod
+        def __prepare__(cls, name, this_bases):
+            return meta.__prepare__(name, bases)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/ExtensionHandler/Linux/src/aria/stats_manager.py
+++ b/ExtensionHandler/Linux/src/aria/stats_manager.py
@@ -1,0 +1,296 @@
+from __future__ import absolute_import
+import datetime 
+import sys
+import time
+import uuid
+import threading
+from .event_properties import EventProperties
+from .log_config import AriaLog
+import aria.log_manager
+
+class StatsConstants(object):
+    SDK_VERSION      = "AST_Python_Linux_no_1.3.9.0"
+    RECORDS_SENT     = "records_sent_count"
+    RECORDS_DROPPED  = "records_dropped_count"
+    RECORDS_RECEIVED = "records_received_count"
+    RECORDS_TRIED = "records_tried_to_send_count"
+    REJECTED_COUNT = "r_count"
+    RECORDS_IN_MEMORY = "infl" 
+    RECORDS_IN_QUEUE = "inq"
+    RECORDS_RETRY = "retry"
+    RECORDS_DROPPED_SERVER_DECLINED = "h_"
+    RETRY_HTTP = "rt_h_"
+    AVERAGE_PACKAGE_SIZE = "aps"
+    TOTAL_DATA_SEND = "tds"
+    AVERAGE_RECORD_SIZE = "ars"
+    DROP_BOND_FAIL = "d_bond_fail"
+    FLUSH_AND_TEAR_DOWN = "ats" # act_teardown_stats
+
+    STATS_CADENCE = 1 * 60
+    event_name = "act_stats"
+    stats_tenant_token = "cdb783887a694494bab466421a591fa3-f8a13b4b-18f4-40fe-976c-c78a3cdb9b8f-7520"
+    tenant_id = "TenantId"
+    tenant = "AST"
+    ast_platform = ""
+    language = "Python"
+    version = "1.3.9.0"
+    python_version = "2"
+    if sys.version_info[0] >= 3:
+        python_version = "3"
+
+    is_wrapper = "no"
+    
+    def PopulateSDKVersion(self):
+        import platform
+        StatsConstants.ast_platform = platform.system()
+        StatsConstants.SDK_VERSION = StatsConstants.tenant + "_" + \
+                                     StatsConstants.ast_platform + "_" + \
+                                     StatsConstants.language + "_" + \
+                                     StatsConstants.python_version + "_" + \
+                                     StatsConstants.is_wrapper + "_" + \
+                                     StatsConstants.version
+
+        AriaLog.aria_log.debug("platform=" + StatsConstants.ast_platform)
+    
+class StatsManager(object):
+    def __init__(self):
+        self.daemon_running = True
+        self.events_dropped_lock =  threading.RLock()
+        self.events_send_lock = threading.RLock()
+        self.events_received_lock = threading.RLock()
+        self.events_tried_lock = threading.RLock()
+        self.stats = {}
+        self.stats_count = {}
+        self.__init_worker_thread()
+        self.flushed = False
+        StatsConstants.cadence = aria.log_manager.LogManagerImpl.configuration.STATS_CADENCE
+
+    def __init_worker_thread(self):
+        self.worker_thread = threading.Thread(target = self.__run)
+        self.worker_thread.daemon = aria.log_manager.LogManagerImpl.configuration.ALL_THREADS_DEAMON 
+        self.worker_thread.start()
+    
+    def __hasStats(self, stat):
+        has_stat = 0
+        has_stat += stat[StatsConstants.RECORDS_SENT] if StatsConstants.RECORDS_SENT in stat else 0
+        has_stat += stat[StatsConstants.RECORDS_DROPPED] if StatsConstants.RECORDS_DROPPED in stat else 0
+        has_stat += stat[StatsConstants.RECORDS_RECEIVED] if StatsConstants.RECORDS_RECEIVED in stat else 0
+        has_stat += stat[StatsConstants.RECORDS_TRIED] if StatsConstants.RECORDS_TRIED in stat else 0
+        
+        return has_stat != 0
+
+    def flush(self):
+        AriaLog.aria_log.info("Flush was called for stats manager")
+        self.flushed = True
+        self.daemon_running = False
+        self.worker_thread.join(3)
+        del self.worker_thread
+        stats_copy = dict(self.stats)
+        self.__sentStats(stats_copy)
+        del self.stats
+        del self
+
+    def __sentStats(self, stats):
+        from aria.log_manager import LogManagerImpl
+        
+        for stat in stats:
+            if self.__hasStats(self.stats[stat]) and stat != StatsConstants.stats_tenant_token:
+                
+                # Creating the tenantID
+                tenant_id_finish_index = stat.index('-')
+                if tenant_id_finish_index == -1:
+                    continue
+                tenant_id = stat[0:tenant_id_finish_index]
+                
+                event = EventProperties(StatsConstants.event_name)
+                event.set_property("sdk-version", StatsConstants.SDK_VERSION)
+                event.set_property("S_t", StatsConstants.tenant)
+                event.set_property("S_p", StatsConstants.ast_platform)
+                event.set_property("S_k", StatsConstants.language)
+                event.set_property("S_j", "no")
+                event.set_property("S_v", StatsConstants.version)
+                event.set_property(StatsConstants.tenant_id, tenant_id)
+                
+                # Adding the stats
+                with self.events_send_lock and self.events_received_lock and self.events_dropped_lock and self.events_tried_lock:
+                    for sub_stat in self.stats[stat]:
+                        if (stat in self.stats_count) and (sub_stat in self.stats_count[stat]):
+                            if self.stats_count[stat][sub_stat] != 0 and self.stats[stat][sub_stat] / self.stats_count[stat][sub_stat] != 0:
+                                event.set_property(sub_stat, str(self.stats[stat][sub_stat] / self.stats_count[stat][sub_stat]))
+                                AriaLog.aria_log.debug(sub_stat + "=" + str(self.stats[stat][sub_stat] / self.stats_count[stat][sub_stat]) + ", Tenant Token=" + stat)
+                                self.stats_count[stat][sub_stat] = 0
+                        elif self.stats[stat][sub_stat] != 0:
+                            event.set_property(sub_stat, str(self.stats[stat][sub_stat]))
+                            AriaLog.aria_log.debug(sub_stat +"=" + str(self.stats[stat][sub_stat]) + ", Tenant Token=" + stat)
+                        self.stats[stat][sub_stat] = 0
+                try:
+                    LogManagerImpl.get_logger("", StatsConstants.stats_tenant_token).log_event(event)
+                except:
+                    pass       
+                 
+    def __run(self):
+        while self.daemon_running:
+            stats_copy = dict(self.stats)
+            self.__sentStats(stats_copy)
+            # For a faster stop for flush
+            for index in range(StatsConstants.STATS_CADENCE):
+                if self.daemon_running and self.daemon_running:
+                    time.sleep(1)
+                else:
+                    return
+            AriaLog.aria_log.info("__run daemon_running end for stats manager")
+            if aria.log_manager.LogManagerImpl.flushed_called == True:
+                self.daemon_running = False
+                return
+                
+    def __get_Stats(self, tenant_token):
+        if tenant_token not in self.stats:
+            self.stats[tenant_token] = {}
+        return self.stats[tenant_token]
+
+    def events_send(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_send_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_SENT not in token_stats:
+                token_stats[StatsConstants.RECORDS_SENT] = 0
+            token_stats[StatsConstants.RECORDS_SENT] += count
+
+    def events_dropped(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_dropped_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_DROPPED not in token_stats:
+                token_stats[StatsConstants.RECORDS_DROPPED] = 0
+            token_stats[StatsConstants.RECORDS_DROPPED] += count
+        
+    def events_received(self, tenant_token, count = 1):
+        if self.flushed == True:
+            return
+        with self.events_received_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_RECEIVED not in token_stats:
+                token_stats[StatsConstants.RECORDS_RECEIVED] = 0
+            token_stats[StatsConstants.RECORDS_RECEIVED] += 1
+
+    def events_tried(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_TRIED not in token_stats:
+                token_stats[StatsConstants.RECORDS_TRIED] = 0
+            token_stats[StatsConstants.RECORDS_TRIED] += count
+    
+    def rejected_count(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.REJECTED_COUNT not in token_stats:
+                token_stats[StatsConstants.REJECTED_COUNT] = 0
+            token_stats[StatsConstants.REJECTED_COUNT] += count
+
+    # TODO
+    def records_in_memory(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_IN_MEMORY not in token_stats:
+                token_stats[StatsConstants.RECORDS_IN_MEMORY] = 0
+            token_stats[StatsConstants.RECORDS_IN_MEMORY] += count
+    
+    # TODO
+    def records_in_queue(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_IN_QUEUE not in token_stats:
+                token_stats[StatsConstants.RECORDS_IN_QUEUE] = 0
+            token_stats[StatsConstants.RECORDS_IN_QUEUE] += count
+    
+    def records_retry(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.RECORDS_RETRY not in token_stats:
+                token_stats[StatsConstants.RECORDS_RETRY] = 0
+            token_stats[StatsConstants.RECORDS_RETRY] += count
+
+    def records_dropped_status(self, tenant_token, count, status):
+        records_dropped_server = StatsConstants.RECORDS_DROPPED_SERVER_DECLINED + str(status)
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if records_dropped_server not in token_stats:
+                token_stats[records_dropped_server] = 0
+            token_stats[records_dropped_server] += count
+            
+    def records_retry_status(self, tenant_token, count, status):
+        records_retry_server = StatsConstants.RETRY_HTTP + str(status)
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if records_retry_server not in token_stats:
+                token_stats[records_retry_server] = 0
+            token_stats[records_retry_server] += count
+            
+    def average_record_size(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            if tenant_token not in self.stats_count:
+                self.stats_count[tenant_token] = {}
+            if StatsConstants.AVERAGE_RECORD_SIZE not in  self.stats_count[tenant_token]:
+                self.stats_count[tenant_token][StatsConstants.AVERAGE_RECORD_SIZE] = 0
+            self.stats_count[tenant_token][StatsConstants.AVERAGE_RECORD_SIZE] += 1
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.AVERAGE_RECORD_SIZE not in token_stats:
+                token_stats[StatsConstants.AVERAGE_RECORD_SIZE] = 0
+            token_stats[StatsConstants.AVERAGE_RECORD_SIZE] += count
+            
+    def average_package_size(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            if tenant_token not in self.stats_count:
+                self.stats_count[tenant_token] = {}
+            if StatsConstants.AVERAGE_PACKAGE_SIZE not in  self.stats_count[tenant_token]:
+                self.stats_count[tenant_token][StatsConstants.AVERAGE_PACKAGE_SIZE] = 0
+            self.stats_count[tenant_token][StatsConstants.AVERAGE_PACKAGE_SIZE] += 1
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.AVERAGE_PACKAGE_SIZE not in token_stats:
+                token_stats[StatsConstants.AVERAGE_PACKAGE_SIZE] = 0
+            token_stats[StatsConstants.AVERAGE_PACKAGE_SIZE] += count
+    
+    def records_bond_failed(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.DROP_BOND_FAIL not in token_stats:
+                token_stats[StatsConstants.DROP_BOND_FAIL] = 0
+            token_stats[StatsConstants.DROP_BOND_FAIL] += count
+    
+    def total_data_send(self, tenant_token, count):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            token_stats = self.__get_Stats(tenant_token)
+            if StatsConstants.TOTAL_DATA_SEND not in token_stats:
+                token_stats[StatsConstants.TOTAL_DATA_SEND] = 0
+            token_stats[StatsConstants.TOTAL_DATA_SEND] += count
+
+    def flush_and_tead_down(self):
+        if self.flushed == True:
+            return
+        with self.events_tried_lock:
+            for k, v  in self.stats.items():
+                self.stats[k][StatsConstants.FLUSH_AND_TEAR_DOWN] = 1

--- a/ExtensionHandler/Linux/src/aria/subscribe.py
+++ b/ExtensionHandler/Linux/src/aria/subscribe.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+from abc import abstractmethod
+from .stats_manager import StatsConstants
+
+class Subscribe(object):
+    def __init__(self):
+        self.__subscribers = []
+        
+    def register(self, observer):
+        self.__subscribers.append(observer)
+        return True
+    
+    def unregister(self, observer):
+        self.__subscribers.remove(observer)
+        return True
+        
+    def unregister_all(self):
+        if self.__subscribers:
+            del self.__subscribers[:]
+        return True
+            
+    def update(self, tenant, sequence_list, result):
+        for subscriber in self.__subscribers:
+            if tenant != StatsConstants.stats_tenant_token:
+                try:
+                    subscriber(tenant, sequence_list, result)
+                except:
+                    pass    #We don't care if your method failed
+        return True
+
+class SubscribeStatus(object):
+    PATCHING_FAILED = -1
+    NO_INTERNET_CONNECTION = -2
+    EVENT_TO_BIG = -3
+    BOND_FAILED = -4
+    MAX_SIZE_REACHED = -5

--- a/ExtensionHandler/Linux/src/aria/utilities.py
+++ b/ExtensionHandler/Linux/src/aria/utilities.py
@@ -1,0 +1,41 @@
+from uuid import uuid1
+from datetime import datetime
+from time import time
+from .log_config import AriaLog
+from io import BytesIO
+from gzip import GzipFile
+import sys
+
+if sys.version_info[0] < 3:
+    from StringIO import StringIO
+            
+class AriaUtilities(object):
+    @staticmethod
+    def generate_guid():
+        return str(uuid1()).lower()
+    
+    @staticmethod
+    def get_utc_time():
+        return str(datetime.utcnow().isoformat())
+
+    @staticmethod
+    def get_current_time_epoch_ms():
+        return int(time()) * 1000
+
+    @staticmethod
+    def convert_ms_to_isoformat(time_in_ms):
+        date_time = datetime.fromtimestamp(time_in_ms / 1000.0)
+        return str(date_time.isoformat())
+
+    @staticmethod
+    def gzip_compress(input_buffer):
+        try:
+            string_buffer = BytesIO() if sys.version_info[0] >= 3 else StringIO()
+            gzip_file = GzipFile(fileobj=string_buffer, mode=u'w', compresslevel = 6)
+            gzip_file.write(input_buffer)
+            gzip_file.close()
+            return string_buffer.getvalue()
+
+        except Exception as e :
+            AriaLog.aria_log.warning("Compressing failed" + str(sys.exc_info()[0]))
+            return None

--- a/ExtensionHandler/Linux/src/net6.json
+++ b/ExtensionHandler/Linux/src/net6.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "alpine",
+    "versions": [
+      {
+        "name": "3.13+"
+      }
+    ]
+  },
+  {
+    "id": "amzn",
+    "versions": [
+      {
+        "name": "2"
+      }
+    ]
+  },
+  {
+    "id": "centos",
+    "versions": [
+      {
+        "name": "7+"
+      }
+    ]
+  },
+  {
+    "id": "debian",
+    "versions": [
+      {
+        "name": "10+"
+      }
+    ]
+  },
+  {
+    "id": "fedora",
+    "versions": [
+      {
+        "name": "33+"
+      }
+    ]
+  },
+  {
+    "id": "macOS",
+    "versions": [
+      {
+        "name": "10.15+"
+      }
+    ]
+  },
+  {
+    "id": "mariner",
+    "versions": [
+      {
+        "name": "1.0+"
+      }
+    ]
+  },
+  {
+    "id": "opensuse-leap",
+    "versions": [
+      {
+        "name": "15+"
+      }
+    ]
+  },
+  {
+    "id": "rhel",
+    "versions": [
+      {
+        "name": "7+"
+      }
+    ]
+  },
+  {
+    "id": "sles",
+    "versions": [
+      {
+        "name": "12.2+"
+      }
+    ]
+  },
+  {
+    "id": "ubuntu",
+    "versions": [
+      {
+        "name": "16.04"
+      },
+      {
+        "name": "18.04"
+      },
+      {
+        "name": "20.04+"
+      }
+
+    ]
+  },
+  {
+    "id": "Windows Client",
+    "versions": [
+      {
+        "name": "7",
+        "version": "7601+"
+      },
+      {
+        "name": "8.1"
+      },
+      {
+        "name": "10",
+        "version": "14393+"
+      }
+    ]
+  },
+  {
+    "id": "Windows Nano Server",
+    "versions": [
+      {
+        "version": "17763+"
+      }
+    ]
+  },
+  {
+    "id": "Windows Server",
+    "versions": [
+      {
+        "name": "2012+"
+      }
+    ]
+  },
+  {
+    "id": "Windows Server Core",
+    "versions": [
+      {
+        "name": "2012+"
+      }
+    ]
+  }
+]

--- a/ExtensionHandler/Linux/src/tests/test_AzureRm.py
+++ b/ExtensionHandler/Linux/src/tests/test_AzureRm.py
@@ -1,0 +1,27 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=invalid-name
+
+import unittest
+from unittest.mock import patch, MagicMock
+import AzureRM
+
+class TestNet6Compatibility(unittest.TestCase):
+    def test_is_os_compatible_returns_None(self):
+        mm = MagicMock()
+        mm.does_system_persists_in_net6_whitelist.return_value = True
+        with patch('AzureRM.handler_utility', mm):
+            self.assertIsNone(AzureRM.os_compatible_with_dotnet6())
+
+    def test_is_os_compatible_raises_exception(self):
+        mm = MagicMock()
+        mm.does_system_persists_in_net6_whitelist.return_value = False
+        with patch('AzureRM.handler_utility', mm):
+            with self.assertRaises(Exception) as context:
+                AzureRM.os_compatible_with_dotnet6()
+            self.assertTrue('https://aka.ms/azdo-pipeline-agent-version' in str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -23,7 +23,6 @@ def urlopen_mock_with_exception():
     mock.read.side_effect = Exception('urlopen error')
     return mock
 
-
 @patch('urllib.request.urlopen', return_value=urlopen_mock_read())
 class TestNet6Deprecation(unittest.TestCase):
     def test_ubuntu_1604(self, _urllib_mock):
@@ -40,7 +39,8 @@ class TestNet6Deprecation(unittest.TestCase):
                              VERSION_CODENAME=xenial
                              UBUNTU_CODENAME=xenial''')
         with patch('builtins.open', mock_open(read_data=os_release)):
-            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            handler_util = HandlerUtil.HandlerUtility("-","-","-","-","-")
+            self.assertTrue(handler_util.does_system_persists_in_net6_whitelist())
 
     def test_ubuntu_2004(self, _urllib_mock):
         os_release = dedent('''
@@ -57,7 +57,8 @@ class TestNet6Deprecation(unittest.TestCase):
                              VERSION_CODENAME=focal
                              UBUNTU_CODENAME=focal''')
         with patch('builtins.open', mock_open(read_data=os_release)):
-            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            handler_util = HandlerUtil.HandlerUtility("-","-","-","-","-")
+            self.assertTrue(handler_util.does_system_persists_in_net6_whitelist())
 
     def test_ubuntu_2204(self, _urllib_mock):
         os_release = dedent('''
@@ -75,7 +76,8 @@ class TestNet6Deprecation(unittest.TestCase):
                             UBUNTU_CODENAME=kinetic
                             LOGO=ubuntu-logo''')
         with patch('builtins.open', mock_open(read_data=os_release)):
-            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            handler_util = HandlerUtil.HandlerUtility("-","-","-","-","-")
+            self.assertTrue(handler_util.does_system_persists_in_net6_whitelist())
 
     def test_rhel_84(self, _urllib_mock):
         os_release = dedent('''
@@ -97,7 +99,8 @@ class TestNet6Deprecation(unittest.TestCase):
                             REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
                             REDHAT_SUPPORT_PRODUCT_VERSION="8.4"''')
         with patch('builtins.open', mock_open(read_data=os_release)):
-            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            handler_util = HandlerUtil.HandlerUtility("-","-","-","-","-")
+            self.assertTrue(handler_util.does_system_persists_in_net6_whitelist())
 
     def test_unknown(self, _urllib_mock):
         os_release = dedent('''
@@ -107,14 +110,16 @@ class TestNet6Deprecation(unittest.TestCase):
                             ID_LIKE="debian"
                             VERSION_ID="0.1"''')
         with patch('builtins.open', mock_open(read_data=os_release)):
-            self.assertFalse(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            handler_util = HandlerUtil.HandlerUtility("-","-","-","-","-")
+            self.assertFalse(handler_util.does_system_persists_in_net6_whitelist())
 
 
 @patch('urllib.request.urlopen', return_value=urlopen_mock_with_exception())
 class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
     def test_file_fallback(self, _urllib_mock):
         with patch('builtins.open', new_callable=mock_open, read_data='{}') as open_mock:
-            self.assertFalse(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            handler_util = HandlerUtil.HandlerUtility("-","-","-","-","-")
+            self.assertFalse(handler_util.does_system_persists_in_net6_whitelist())
             # first open is for /etc/os-release
             # second open should happen due to urllib.request.urlopen exception
             # while trying to open ../net6.json

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -1,0 +1,123 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=invalid-name
+
+import unittest
+from textwrap import dedent
+from unittest.mock import patch, MagicMock
+from mock import mock_open
+from Utils import HandlerUtil
+
+
+def urlopen_mock_read():
+    mock = MagicMock()
+    with open("net6.json", "r", encoding='utf-8') as net6_file:
+        mock.read.return_value = net6_file.read()
+    return mock
+
+def urlopen_mock_with_exception():
+    mock = MagicMock()
+    mock.read.side_effect = Exception('urlopen error')
+    return mock
+
+
+@patch('urllib.request.urlopen', return_value=urlopen_mock_read())
+class TestNet6Deprecation(unittest.TestCase):
+    def test_ubuntu_1604(self, _urllib_mock):
+        os_release = dedent('''
+                             NAME="Ubuntu"
+                             VERSION="16.04.7 LTS (Xenial Xerus)"
+                             ID=ubuntu
+                             ID_LIKE=debian
+                             PRETTY_NAME="Ubuntu 16.04.7 LTS"
+                             VERSION_ID="16.04"
+                             HOME_URL="http://www.ubuntu.com/"
+                             SUPPORT_URL="http://help.ubuntu.com/"
+                             BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+                             VERSION_CODENAME=xenial
+                             UBUNTU_CODENAME=xenial''')
+        with patch('builtins.open', mock_open(read_data=os_release)):
+            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+
+    def test_ubuntu_2004(self, _urllib_mock):
+        os_release = dedent('''
+                             NAME="Ubuntu"
+                             VERSION="20.04.3 LTS (Focal Fossa)"
+                             ID=ubuntu
+                             ID_LIKE=debian
+                             PRETTY_NAME="Ubuntu 20.04.3 LTS"
+                             VERSION_ID="20.04"
+                             HOME_URL="https://www.ubuntu.com/"
+                             SUPPORT_URL="https://help.ubuntu.com/"
+                             BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+                             PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+                             VERSION_CODENAME=focal
+                             UBUNTU_CODENAME=focal''')
+        with patch('builtins.open', mock_open(read_data=os_release)):
+            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+
+    def test_ubuntu_2204(self, _urllib_mock):
+        os_release = dedent('''
+                            PRETTY_NAME="Ubuntu 22.10"
+                            NAME="Ubuntu"
+                            VERSION_ID="22.10"
+                            VERSION="22.10 (Kinetic Kudu)"
+                            VERSION_CODENAME=kinetic
+                            ID=ubuntu
+                            ID_LIKE=debian
+                            HOME_URL="https://www.ubuntu.com/"
+                            SUPPORT_URL="https://help.ubuntu.com/"
+                            BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+                            PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+                            UBUNTU_CODENAME=kinetic
+                            LOGO=ubuntu-logo''')
+        with patch('builtins.open', mock_open(read_data=os_release)):
+            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+
+    def test_rhel_84(self, _urllib_mock):
+        os_release = dedent('''
+                            NAME="Red Hat Enterprise Linux"
+                            VERSION="8.4 (Ootpa)"
+                            ID="rhel"
+                            ID_LIKE="fedora"
+                            VERSION_ID="8.4"
+                            PLATFORM_ID="platform:el8"
+                            PRETTY_NAME="Red Hat Enterprise Linux 8.4 (Ootpa)"
+                            ANSI_COLOR="0;31"
+                            CPE_NAME="cpe:/o:redhat:enterprise_linux:8.4:GA"
+                            HOME_URL="https://www.redhat.com/"
+                            DOCUMENTATION_URL="https://access.redhat.com/documentation/red_hat_enterprise_linux/8/"
+                            BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+                            REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
+                            REDHAT_BUGZILLA_PRODUCT_VERSION=8.4
+                            REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+                            REDHAT_SUPPORT_PRODUCT_VERSION="8.4"''')
+        with patch('builtins.open', mock_open(read_data=os_release)):
+            self.assertTrue(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+
+    def test_unknown(self, _urllib_mock):
+        os_release = dedent('''
+                            NAME="Unknown Linux"
+                            VERSION="0.1"
+                            ID="unknown"
+                            ID_LIKE="debian"
+                            VERSION_ID="0.1"''')
+        with patch('builtins.open', mock_open(read_data=os_release)):
+            self.assertFalse(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+
+
+@patch('urllib.request.urlopen', return_value=urlopen_mock_with_exception())
+class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
+    def test_file_fallback(self, _urllib_mock):
+        with patch('builtins.open', new_callable=mock_open, read_data='{}') as open_mock:
+            self.assertFalse(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
+            # first open is for /etc/os-release
+            # second open should happen due to urllib.request.urlopen exception
+            # while trying to open ../net6.json
+            self.assertEqual(open_mock.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -6,6 +6,8 @@
 import unittest
 from textwrap import dedent
 from unittest.mock import patch, MagicMock
+import json
+import urllib.request
 from mock import mock_open
 from Utils import HandlerUtil
 
@@ -118,6 +120,14 @@ class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
             # while trying to open ../net6.json
             self.assertEqual(open_mock.call_count, 2)
 
+class TestNet6FileConsistency(unittest.TestCase):
+    def test_file_consistency(self):
+        with open("net6.json", encoding="utf-8") as net6_file:
+            local = json.loads(net6_file.read())
+        remote_net6_fileurl = "https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json"
+        with urllib.request.urlopen(remote_net6_fileurl) as remote_net6_file:
+            remote = json.loads(remote_net6_file.read())
+        self.assertEqual(local, remote)
 
 if __name__ == '__main__':
     unittest.main()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,5 +20,5 @@ steps:
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
 
 # For now run pylint only for the tests which is new code
-- script: cd ExtensionHandler/Linux/src && pylint tests
+- script: pylint ExtensionHandler/Linux/src/tests
   displayName: 'Run pylint'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,24 @@
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+- script: |
+     sudo apt-get install python3-coverage python3-mock pylint python3-pytest python3-pytest-cov
+  displayName: Install python dependencies
+
+- script: cd ExtensionHandler/Linux/src && pytest-3 --junitxml=test-results.xml --cov=.  --cov-report=xml
+  displayName: 'Run Linux tests'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '**/test-*.xml'
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+
+# For now run pylint only for the tests which is new code
+- script: cd ExtensionHandler/Linux/src && pylint tests
+  displayName: 'Run pylint'

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,3 @@
+[FORMAT]
+max-line-length=160
+


### PR DESCRIPTION
Fail provisioning an agent on Linux if the OS is not supported by the new .NET 6 based v3 agent. Same feature also implemented for the Windows extension #215 

Tested on Ubuntu 20.04 and Oracle Linux 6.8
- Successfully downloads and configures an agent on Ubuntu 20.04
- Fails on Oracle Linux with the following error
![image (1)](https://user-images.githubusercontent.com/117078846/230014325-428727ac-3951-4ded-a139-813795ba2145.png)