### PR TITLE
Add check for consistency of net6.json file

### DIFF
--- a/ExtensionHandler/Windows/src/Tests/EnsureNet6FileConsistent.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/EnsureNet6FileConsistent.Tests.ps1
@@ -1,0 +1,10 @@
+Describe "Ensure Net6 File Consistent Tests" {
+
+    Context "The local copy of the net6.json file should be consistent with the original maintained in the azure-pipelines-agent repo" {
+        It "should verify that local copy of net6.json is same as the original file maintained in the azure-pipelines-agent repo " {
+            $local = (Get-Content "..\net6.json" -Raw) | ConvertFrom-Json
+            $remote = Invoke-WebRequest "https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json" -UseBasicParsing | ConvertFrom-Json
+            $local | Should -Be $remote
+        }
+    }
+}

--- a/ExtensionHandler/Windows/src/Tests/EnsureNet6FileConsistent.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/EnsureNet6FileConsistent.Tests.ps1
@@ -1,7 +1,7 @@
 Describe "Ensure Net6 File Consistent Tests" {
 
-    Context "The local copy of the net6.json file should be consistent with the original maintained in the azure-pipelines-agent repo" {
-        It "should verify that local copy of net6.json is same as the original file maintained in the azure-pipelines-agent repo " {
+    Context "The local copy of the net6.json file should be consistent with the original file maintained in the azure-pipelines-agent repo" {
+        It "should verify that local copy of net6.json does not have any discrepancies with https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json" {
             $local = (Get-Content "..\net6.json" -Raw) | ConvertFrom-Json
             $remote = Invoke-WebRequest "https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json" -UseBasicParsing | ConvertFrom-Json
             $diff = Compare-Object -ReferenceObject $local -DifferenceObject $remote

--- a/ExtensionHandler/Windows/src/Tests/EnsureNet6FileConsistent.Tests.ps1
+++ b/ExtensionHandler/Windows/src/Tests/EnsureNet6FileConsistent.Tests.ps1
@@ -4,7 +4,8 @@ Describe "Ensure Net6 File Consistent Tests" {
         It "should verify that local copy of net6.json is same as the original file maintained in the azure-pipelines-agent repo " {
             $local = (Get-Content "..\net6.json" -Raw) | ConvertFrom-Json
             $remote = Invoke-WebRequest "https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json" -UseBasicParsing | ConvertFrom-Json
-            $local | Should -Be $remote
+            $diff = Compare-Object -ReferenceObject $local -DifferenceObject $remote
+            $diff -eq $null | Should -Be $true
         }
     }
 }

--- a/ExtensionHandler/Windows/src/net6.json
+++ b/ExtensionHandler/Windows/src/net6.json
@@ -125,5 +125,13 @@
         "name": "2012+"
       }
     ]
+  },
+  {
+    "id": "Windows Server Core",
+    "versions": [
+      {
+        "name": "2012+"
+      }
+    ]
   }
 ]

--- a/ExtensionHandler/Windows/src/net6.json
+++ b/ExtensionHandler/Windows/src/net6.json
@@ -125,13 +125,5 @@
         "name": "2012+"
       }
     ]
-  },
-  {
-    "id": "Windows Server Core",
-    "versions": [
-      {
-        "name": "2012+"
-      }
-    ]
   }
 ]


### PR DESCRIPTION
Add a new test to ensure that the copy of net6.json file in the repo is identical to the file maintained in the azure-pipelines-agent repo