### PR TITLE
Add check for consistency of net6.json file in the Linux extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ e2eTests/publicConfig.json
 e2eTests/template.json
 e2eTests/TestEnvironment.json
 .vscode/launch.json
+.venv

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -2,7 +2,6 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=invalid-name
-# pylint: disable=line-too-long
 
 import unittest
 from textwrap import dedent

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -6,10 +6,10 @@
 import unittest
 from textwrap import dedent
 from unittest.mock import patch, MagicMock
-from mock import mock_open
-from Utils import HandlerUtil
 import json
 import urllib.request
+from mock import mock_open
+from Utils import HandlerUtil
 
 
 def urlopen_mock_read():
@@ -122,9 +122,12 @@ class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
 
 class TestNet6FileConsistency(unittest.TestCase):
     def test_file_consistency(self):
-        with open("net6.json") as net6_file:
+        with open("net6.json", encoding="utf-8") as net6_file:
             local = json.loads(net6_file.read())
-        remote = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        remote_net6_fileurl = dedent('''
+                                    https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json''')
+        with urllib.request.urlopen(remote_net6_fileurl) as remote_net6_file:
+            remote = json.loads(remote_net6_file.read())
         self.assertEqual(local, remote)
 
 if __name__ == '__main__':

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -112,12 +112,6 @@ class TestNet6Deprecation(unittest.TestCase):
 
 @patch('urllib.request.urlopen', return_value=urlopen_mock_with_exception())
 class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
-    def test_file_consistency(self,_urllib_mock):
-        with open("net6.json") as net6_file:
-            local = json.loads(net6_file.read())
-        remote = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
-        self.assertEqual(local, remote)
-
     def test_file_fallback(self, _urllib_mock):
         with patch('builtins.open', new_callable=mock_open, read_data='{}') as open_mock:
             self.assertFalse(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())
@@ -126,6 +120,12 @@ class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
             # while trying to open ../net6.json
             self.assertEqual(open_mock.call_count, 2)
 
+class TestNet6FileConsistency(unittest.TestCase):
+    def test_file_consistency(self, _urllib_mock):
+        with open("net6.json") as net6_file:
+            local = json.loads(net6_file.read())
+        remote = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        self.assertEqual(local, remote)
 
 if __name__ == '__main__':
     unittest.main()

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -8,6 +8,8 @@ from textwrap import dedent
 from unittest.mock import patch, MagicMock
 from mock import mock_open
 from Utils import HandlerUtil
+import json
+import urllib.request
 
 
 def urlopen_mock_read():
@@ -111,7 +113,7 @@ class TestNet6Deprecation(unittest.TestCase):
 @patch('urllib.request.urlopen', return_value=urlopen_mock_with_exception())
 class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
     def test_file_consistency(self,_urllib_mock):
-        with open("../net6.json") as net6_file:
+        with open("net6.json") as net6_file:
             local = json.loads(net6_file.read())
         remote = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
         self.assertEqual(local, remote)

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -121,7 +121,7 @@ class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
             self.assertEqual(open_mock.call_count, 2)
 
 class TestNet6FileConsistency(unittest.TestCase):
-    def test_file_consistency(self, _urllib_mock):
+    def test_file_consistency(self):
         with open("net6.json") as net6_file:
             local = json.loads(net6_file.read())
         remote = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=invalid-name
+# pylint: disable=line-too-long
 
 import unittest
 from textwrap import dedent
@@ -124,8 +125,7 @@ class TestNet6FileConsistency(unittest.TestCase):
     def test_file_consistency(self):
         with open("net6.json", encoding="utf-8") as net6_file:
             local = json.loads(net6_file.read())
-        remote_net6_fileurl = dedent('''
-                                    https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json''')
+        remote_net6_fileurl = "https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json"
         with urllib.request.urlopen(remote_net6_fileurl) as remote_net6_file:
             remote = json.loads(remote_net6_file.read())
         self.assertEqual(local, remote)

--- a/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
+++ b/ExtensionHandler/Linux/src/tests/test_HandlerUtil.py
@@ -110,6 +110,12 @@ class TestNet6Deprecation(unittest.TestCase):
 
 @patch('urllib.request.urlopen', return_value=urlopen_mock_with_exception())
 class TestNet6DeprecationLocalFileFallback(unittest.TestCase):
+    def test_file_consistency(self,_urllib_mock):
+        with open("../net6.json") as net6_file:
+            local = json.loads(net6_file.read())
+        remote = json.loads(urllib.request.urlopen("https://raw.githubusercontent.com/microsoft/azure-pipelines-agent/master/src/Agent.Listener/net6.json").read())
+        self.assertEqual(local, remote)
+
     def test_file_fallback(self, _urllib_mock):
         with patch('builtins.open', new_callable=mock_open, read_data='{}') as open_mock:
             self.assertFalse(HandlerUtil.HandlerUtility.does_system_persists_in_net6_whitelist())

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,5 +20,5 @@ steps:
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
 
 # For now run pylint only for the tests which is new code
-- script: cd ExtensionHandler/Linux/src && pylint tests
+- script: pylint ExtensionHandler/Linux/src/tests
   displayName: 'Run pylint'

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,3 @@
+[FORMAT]
+max-line-length=160
+


### PR DESCRIPTION
Add a new test to ensure that the copy of net6.json file in the Linux extension of the repo is identical to the file maintained in the azure-pipelines-agent repo