### PR TITLE
Update Gulpfile to Publish Aria

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('createTempWindowsHandlerPackage', function () {
 
 gulp.task('createTempLinuxHandlerPackage', function () {
 	gutil.log("Copying linux extension handler files selectively to temp location: " + tempLinuxHandlerFilesPath);
-	return gulp.src(['ExtensionHandler/Linux/src/**.**', 'ExtensionHandler/Linux/src/Utils/**.**', 'ExtensionHandler/Linux/src/Utils_python2/**.**'],  {base: 'ExtensionHandler/Linux/src/'})
+	return gulp.src(['ExtensionHandler/Linux/src/**.**', 'ExtensionHandler/Linux/src/Utils/**.**', 'ExtensionHandler/Linux/src/Utils_python2/**.**', 'ExtensionHandler/Linux/src/aria/**.**'],  {base: 'ExtensionHandler/Linux/src/'})
 	.pipe(gulp.dest(tempLinuxHandlerFilesPath));
 });
 


### PR DESCRIPTION
Need to update gulpfile.js to publish Aria, else the extension will throw errors due to missing aria files.