### PR TITLE
add Makefile for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,117 @@
+.DEFAULT_GOAL := build
+
+workdir := $(shell pwd)
+
+outputPath := _build
+tempLocation := _temp
+tempPackagePath := $(tempLocation)/VSTSExtensionTemp
+tempWindowsHandlerFilesPath := $(tempPackagePath)/ExtensionHandler/Windows
+windowsHandlerArchievePackageLocation := $(outputPath)/ExtensionHandler/Windows
+tempLinuxHandlerFilesPath := $(tempPackagePath)/ExtensionHandler/Linux
+linuxHandlerArchievePackageLocation := $(outputPath)/ExtensionHandler/Linux
+
+armUIPackageLocation := $(outputPath)/UI\ Package/Windows/ARM
+classicUIPackageLocation := $(outputPath)/UI\ Package/Windows/Classic
+armUIPackageSource := UI\ Package/Windows/ARM
+classicUIPackageSource := UI\ Package/Windows/Classic
+
+linuxarmUIPackageLocation := $(outputPath)/UI\ Package/Linux/ARM
+linuxclassicUIPackageLocation := $(outputPath)/UI\ Package/Linux/Classic
+linuxarmUIPackageSource := UI\ Package/Linux/ARM
+linuxclassicUIPackageSource := UI\ Package/Linux/Classic
+
+
+cleanExistingBuild:
+	@echo "Cleaning existing build... $(outputPath)"
+	@rm -rf $(outputPath)
+
+cleanTempFolder:
+	@echo "Cleaning temp folder..."
+	@rm -rf $(tempLocation)
+
+clean: cleanExistingBuild cleanTempFolder
+
+copyLinuxHandlerDefinitionFile:
+	@echo "Copying Linux handler definition file..."
+	@mkdir -p $(linuxHandlerArchievePackageLocation)
+	@cp ExtensionHandler/Linux/ExtensionDefinition_Test_MIGRATED.xml $(linuxHandlerArchievePackageLocation)/
+	@cp ExtensionHandler/Linux/ExtensionDefinition_Prod_MIGRATED.xml $(linuxHandlerArchievePackageLocation)/
+
+createTempLinuxHandlerPackage: copyLinuxHandlerDefinitionFile
+	@echo "Creating temp Linux handler package..."
+	@mkdir -p $(tempLinuxHandlerFilesPath) $(tempLinuxHandlerFilesPath)/Utils $(tempLinuxHandlerFilesPath)/Utils_python2 $(tempLinuxHandlerFilesPath)/aria
+	@cp ExtensionHandler/Linux/src/**.** $(tempLinuxHandlerFilesPath)/
+	@cp ExtensionHandler/Linux/src/Utils/**.** $(tempLinuxHandlerFilesPath)/Utils
+	@cp ExtensionHandler/Linux/src/Utils_python2/**.** $(tempLinuxHandlerFilesPath)/Utils_python2
+	@cp ExtensionHandler/Linux/src/aria/**.** $(tempLinuxHandlerFilesPath)/aria
+
+createLinuxHandlerPackage: createTempLinuxHandlerPackage
+	@echo "Creating Linux handler package..."
+	@mkdir -p $(linuxHandlerArchievePackageLocation)
+	@cd $(tempLinuxHandlerFilesPath) && zip -9 -r $(workdir)/$(linuxHandlerArchievePackageLocation)/RMExtension.zip *
+
+copyWindowsHandlerDefinitionFile:
+	@echo "Copying Windows handler definition file..."
+	@mkdir -p $(windowsHandlerArchievePackageLocation)
+	@cp ExtensionHandler/Windows/ExtensionDefinition_Test_MIGRATED.xml $(windowsHandlerArchievePackageLocation)/
+	@cp ExtensionHandler/Windows/ExtensionDefinition_Prod_MIGRATED.xml $(windowsHandlerArchievePackageLocation)/
+
+createTempWindowsHandlerPackage: copyWindowsHandlerDefinitionFile
+	@echo "Creating temp Windows handler package..."
+	@mkdir -p $(tempWindowsHandlerFilesPath)/src/bin/
+	@cp ExtensionHandler/Windows/src/bin/* $(tempWindowsHandlerFilesPath)/src/bin/
+	@cp ExtensionHandler/Windows/src/enable.cmd $(tempWindowsHandlerFilesPath)/src/
+	@cp ExtensionHandler/Windows/src/disable.cmd $(tempWindowsHandlerFilesPath)/src/
+	@cp ExtensionHandler/Windows/src/install.cmd $(tempWindowsHandlerFilesPath)/src/
+	@cp ExtensionHandler/Windows/src/uninstall.cmd $(tempWindowsHandlerFilesPath)/src/
+	@cp ExtensionHandler/Windows/src/update.cmd $(tempWindowsHandlerFilesPath)/src/
+	@cp ExtensionHandler/Windows/src/HandlerManifest.json $(tempWindowsHandlerFilesPath)/src/
+	@cp ExtensionHandler/Windows/src/net6.json $(tempWindowsHandlerFilesPath)/src/
+
+createWindowsHandlerPackage: createTempWindowsHandlerPackage
+	@echo "Creating Windows handler package... $(tempWindowsHandlerFilesPath)"
+	@mkdir -p $(windowsHandlerArchievePackageLocation)
+	@cd $(tempWindowsHandlerFilesPath)/src && zip -9 -r $(workdir)/$(windowsHandlerArchievePackageLocation)/RMExtension.zip *
+
+generateWindowsTestArtifacts:
+	@echo "Generating Windows test artifacts..."
+	@pwsh CDScripts/Ev2ArtifactsGenerator.ps1 -outputDir $(windowsHandlerArchievePackageLocation)/Test -ExtensionInfoFile $(windowsHandlerArchievePackageLocation)/ExtensionDefinition_Test_MIGRATED.xml -PackageFile $(windowsHandlerArchievePackageLocation)/RMExtension.zip
+
+generateWindowsProdArtifacts:
+	@echo "Generating Windows prod artifacts..."
+	@pwsh CDScripts/Ev2ArtifactsGenerator.ps1 -outputDir $(windowsHandlerArchievePackageLocation)/Prod -ExtensionInfoFile $(windowsHandlerArchievePackageLocation)/ExtensionDefinition_Prod_MIGRATED.xml -PackageFile $(windowsHandlerArchievePackageLocation)/RMExtension.zip
+
+generateLinuxTestArtifacts:
+	@echo "Generating Linux test artifacts..."
+	@pwsh CDScripts/Ev2ArtifactsGenerator.ps1 -outputDir $(linuxHandlerArchievePackageLocation)/Test -ExtensionInfoFile $(linuxHandlerArchievePackageLocation)/ExtensionDefinition_Test_MIGRATED.xml -PackageFile $(linuxHandlerArchievePackageLocation)/RMExtension.zip
+
+generateLinuxProdArtifacts:
+	@echo "Generating Linux prod artifacts..."
+	@pwsh CDScripts/Ev2ArtifactsGenerator.ps1 -outputDir $(linuxHandlerArchievePackageLocation)/Prod -ExtensionInfoFile $(linuxHandlerArchievePackageLocation)/ExtensionDefinition_Prod_MIGRATED.xml -PackageFile $(linuxHandlerArchievePackageLocation)/RMExtension.zip
+
+createWindowsUIPackage:
+	@echo "Creating Windows UI package..."
+	@mkdir -p $(armUIPackageLocation) $(classicUIPackageLocation)
+	@cd $(armUIPackageSource) && zip -9 -r $(workdir)/$(armUIPackageLocation)/UIPackage.zip *
+	@cd $(classicUIPackageSource) && zip -9 -r $(workdir)/$(classicUIPackageLocation)/UIPackage.zip *
+
+createLinuxUIPackage:
+	@echo "Creating Linux UI package..."
+	@mkdir -p $(linuxarmUIPackageLocation) $(linuxclassicUIPackageLocation)
+	@cd $(linuxarmUIPackageSource)/ && zip -9 -r $(workdir)/$(linuxarmUIPackageLocation)/UIPackage.zip *
+	@cd $(linuxclassicUIPackageSource)/ && zip -9 -r $(workdir)/$(linuxclassicUIPackageLocation)/UIPackage.zip *
+
+build:
+	@echo "Building $(outputPath)..."
+	@echo "workdir = $(workdir)"
+	$(MAKE) cleanExistingBuild
+	$(MAKE) cleanTempFolder
+	$(MAKE) createLinuxHandlerPackage
+	$(MAKE) createWindowsHandlerPackage
+	$(MAKE) generateWindowsTestArtifacts
+	$(MAKE) generateWindowsProdArtifacts
+	$(MAKE) generateLinuxTestArtifacts
+	$(MAKE) generateLinuxProdArtifacts
+	$(MAKE) createWindowsUIPackage
+	$(MAKE) createLinuxUIPackage
+	@echo "Build completed successfully."


### PR DESCRIPTION
Add Makefile for building.

Followups: migrate pipeline producing artifacts to Linux, as `make` command is not available on Windows.

Possible issues: files under _build directory have `777` permissions but they need to be `666`. I will followup on this in future PR which will address building as it might be caused by WSL.

Testing:
Contents of _build directory produced by Makefile and gulp are identical:
![obrazek](https://github.com/user-attachments/assets/8e1b6f18-0d34-436e-92a6-1b4e19b287b8)

Contents of RMExtension.zip for both Windows and Linux are identical:
![obrazek](https://github.com/user-attachments/assets/55c47bdf-816c-43c6-af06-3c50717a08ec)

![obrazek](https://github.com/user-attachments/assets/3eb4b36f-4a9a-4676-8331-1d12873f300b)


Contents of UI Packages (both Classic and RM) for both Windows and Linux:
![obrazek](https://github.com/user-attachments/assets/3b5ee468-4219-445e-916e-3a894f9d9faf)

![obrazek](https://github.com/user-attachments/assets/2ce673a5-a94c-4815-83f0-0d389557f061)

![obrazek](https://github.com/user-attachments/assets/f8946d4a-8594-4cd3-aeb7-147e4fc9fe57)

![obrazek](https://github.com/user-attachments/assets/c5dab35c-0409-4e1d-8670-2f7a99e1feaa)
