### PR TITLE
Sign 'Manage VM extensions in Azure PIR' extension

### DIFF
--- a/Extensions/ManageAzureVMExtension/Src/vss-extension.json
+++ b/Extensions/ManageAzureVMExtension/Src/vss-extension.json
@@ -3,7 +3,7 @@
 	"id": "vss-services-manageazurevmextension",
 	"name": "Manage VM extensions in Azure PIR ",
 	"publisher": "ms-vscs-rm",
-	"version": "0.0.14",
+	"version": "0.262.0",
 	"public": false,
 	"description": "Manage VM extensions in Azure Platform Image Repository.",
 	"categories": [


### PR DESCRIPTION
Update the version number in order to sign the artifact of the extension and publish it on Marketplace.

The extension is signed using 'workaround' approach because release pipeline for Release Management team is not supported to work with this repository and the metrics are showing that this extension is not used or installed by any organization (even though it is shared with a few of them). Therefore, the most convenient approach for signing is used and future usage will be tracked with the idea to abandon the support if it's not used by anyone till 1st November 2025.

It has been decided that investing time in pipeline configuration is not worth at the moment, until future of the extension is decided.

More details about signing process can be found in internal documents and the related [PR](https://github.com/microsoft/azure-pipelines-extensions/pull/1291) from another repository.